### PR TITLE
Add support to use user input as git committer

### DIFF
--- a/lib/Staticman.js
+++ b/lib/Staticman.js
@@ -178,7 +178,7 @@ Staticman.prototype._resolvePlaceholders = function (subject, baseObject) {
   return subject
 }
 
-Staticman.prototype._sendPullRequest = function (data, uid) {
+Staticman.prototype._sendPullRequest = function (fields, data, uid) {
   var branch = 'staticman_' + uid
 
   return this.github.repos.getBranch({
@@ -193,7 +193,7 @@ Staticman.prototype._sendPullRequest = function (data, uid) {
       sha: res.commit.sha
     })
   }).then((res) => {
-    return this._uploadFile(data, uid, 'staticman_' + uid)
+    return this._uploadFile(fields, data, uid, 'staticman_' + uid)
   }).then((res) => {
     return this.github.pullRequests.create({
       user: this.options.username,
@@ -298,7 +298,7 @@ Staticman.prototype._validateFields = function (fields) {
   return null
 }
 
-Staticman.prototype._uploadFile = function (data, uid, branch) {
+Staticman.prototype._uploadFile = function (fields, data, uid, branch) {
   branch = branch || this.config.branch
 
   var filename = this.config.filename ? this._resolvePlaceholders(this.config.filename, {
@@ -310,14 +310,23 @@ Staticman.prototype._uploadFile = function (data, uid, branch) {
     options: this.options
   })
 
-  return this.github.repos.createFile({
+  var params = {
     user: this.options.username,
     repo: this.options.repository,
     path: path + '/' + filename + '.' + this._getExtensionForFormat(this.config.format),
     content: new Buffer(data).toString('base64'),
     message: this.config.commitTitle,
     branch: branch
-  })
+  };
+
+  if (this.config.commit && this.config.commit.name && this.config.commit.email) {
+    params['committer'] = {
+      name: fields[this.config.commit.name],
+      email: fields[this.config.commit.email]
+    }
+  }
+
+  return this.github.repos.createFile(params)
 }
 
 Staticman.prototype.initGithub = function () {
@@ -360,10 +369,10 @@ Staticman.prototype.process = function (fields, options) {
     return this._createFile(transformedFields)
   }).then((file) => {
     if (this.config.moderation) {
-      return this._sendPullRequest(file, uid)
+      return this._sendPullRequest(fields, file, uid)
     }
 
-    return this._uploadFile(file, uid)
+    return this._uploadFile(fields, file, uid)
   }).then((result) => {
     return {
       fields: fields,


### PR DESCRIPTION
The following config option enables this

``` yaml
commit:
  name: name # field
  email: email # field
```

The comment commit will use the user inputted name and email.
