### PR TITLE
Added more fields to Akismet

### DIFF
--- a/controllers/process.js
+++ b/controllers/process.js
@@ -26,6 +26,7 @@ module.exports = (config) => {
 
     staticman.setConfig(createConfigObject(res.locals.apiVersion))
     staticman.setIp(req.headers['x-forwarded-for'] || req.connection.remoteAddress)
+    staticman.setUserAgent(req.headers['user-agent'])
 
     staticman.process(fields, options).then((data) => {
       if (data.redirect) {

--- a/lib/Staticman.js
+++ b/lib/Staticman.js
@@ -56,7 +56,11 @@ Staticman.prototype._checkForSpam = function (fields) {
 
     akismet.checkSpam({
       user_ip: this.ip,
+      user_agent: this.useragent,
+      comment_type: "comment",
       comment_author: fields[this.config.akismet.author],
+      comment_author_email: fields[this.config.akismet.email],
+      comment_author_url: fields[this.config.akismet.url],
       comment_content: fields[this.config.akismet.content]
     }, (err, isSpam) => {
       if (err) return reject(err)
@@ -378,6 +382,10 @@ Staticman.prototype.setConfig = function (config) {
 
 Staticman.prototype.setIp = function (ip) {
   this.ip = ip
+}
+
+Staticman.prototype.setUserAgent = function (useragent) {
+  this.useragent = useragent
 }
 
 module.exports = Staticman

--- a/lib/Staticman.js
+++ b/lib/Staticman.js
@@ -46,7 +46,7 @@ Staticman.prototype._applyTransforms = function (data) {
 }
 
 Staticman.prototype._checkForSpam = function (fields) {
-  if (!this.config.akismet || !this.config.akismet.enabled) return Promise.resolve(fields)
+  if (!this.config.akismet || !this.config.akismet.type) return Promise.resolve(fields)
 
   return new Promise((resolve, reject) => {
     var akismet = require('akismet').client({
@@ -57,7 +57,7 @@ Staticman.prototype._checkForSpam = function (fields) {
     akismet.checkSpam({
       user_ip: this.ip,
       user_agent: this.useragent,
-      comment_type: "comment",
+      comment_type: this.config.akismet.type,
       comment_author: fields[this.config.akismet.author],
       comment_author_email: fields[this.config.akismet.email],
       comment_author_url: fields[this.config.akismet.url],


### PR DESCRIPTION
Added more Akismet options in addition, the user-agent and comment_type will be sent to akismet.

``` yaml
akismet:
  type: comment
  author: name #field
  content: message #field
  email: email #field
  url: url #field
```

Note I replaced the "enabled" option with "type" for comment_type.
