### PR TITLE
Fix recaptcha origin bug

### DIFF
--- a/controllers/process.js
+++ b/controllers/process.js
@@ -2,45 +2,7 @@
 
 const config = require(__dirname + '/../config')
 const Staticman = require('../lib/Staticman')
-const reCaptcha = require('express-recaptcha')
-
-function checkRecaptcha(staticman, req) {
-  return new Promise((resolve, reject) => {
-    staticman.getSiteConfig().then(siteConfig => {
-      if (!siteConfig.get('reCaptcha.enabled')) {
-        return resolve(false)
-      }
-
-      const reCaptchaOptions = req.body.options && req.body.options.reCaptcha
-
-      if (!reCaptchaOptions || !reCaptchaOptions.siteKey || !reCaptchaOptions.secret) {
-        return reject('Missing reCAPTCHA API credentials')
-      }
-
-      let decryptedSecret
-
-      try {
-        decryptedSecret = staticman.decrypt(reCaptchaOptions.secret)
-      } catch (err) {
-        return reject('Could not decrypt reCAPTCHA secret')
-      }
-
-      if ((reCaptchaOptions.siteKey) !== siteConfig.get('reCaptcha.siteKey') ||
-        (decryptedSecret !== siteConfig.get('reCaptcha.secret'))) {
-        return reject('reCAPTCHA options do not match Staticman config')
-      }
-
-      reCaptcha.init(reCaptchaOptions.siteKey, decryptedSecret)
-      reCaptcha.verify(req, err => {
-        if (err) {
-          return reject(getRecaptchaError(err))
-        }
-
-        return resolve(true)
-      })
-    }).catch(err => reject(err))
-  })
-}
+const Captcha = require('../lib/Captcha')
 
 function createConfigObject(apiVersion, property) {
   let remoteConfig = {}
@@ -56,30 +18,12 @@ function createConfigObject(apiVersion, property) {
   return remoteConfig
 }
 
-function getRecaptchaError(errorCode) {
-  switch (errorCode) {
-    case 'missing-input-secret':
-      return 'reCAPTCHA: The secret parameter is missing'
-
-    case 'invalid-input-secret':
-      return 'reCAPTCHA: The secret parameter is invalid or malformed'
-
-    case 'missing-input-response':
-      return 'reCAPTCHA: The response parameter is missing'
-
-    case 'invalid-input-response':
-      return 'reCAPTCHA: The response parameter is invalid or malformed'
-  }
-
-  return errorCode
-}
-
 function process(staticman, req, res) {
   const ua = config.get('analytics.uaTrackingId') ? require('universal-analytics')(config.get('analytics.uaTrackingId')) : null
   const fields = req.query.fields || req.body.fields
   const options = req.query.options || req.body.options || {}
 
-  return staticman.processEntry(fields, options).then(data => {
+  return staticman.processEntry().then(data => {
     sendResponse(res, {
       redirect: data.redirect,
       fields: data.fields
@@ -92,7 +36,7 @@ function process(staticman, req, res) {
     console.log('** ERR:', err.stack || err, options, fields, req.params)
 
     sendResponse(res, {
-      error: err,
+      error: err.stack,
       errorCode: 'ENTRY_ERROR',
       redirectError: req.body.options.redirectError
     })
@@ -114,7 +58,7 @@ function sendResponse(res, data) {
     return res.redirect(data.redirectError)
   }
 
-  let payload = {
+  const payload = {
     success: !data.error
   }
 
@@ -129,18 +73,19 @@ function sendResponse(res, data) {
 }
 
 module.exports = (req, res, next) => {
-  const staticman = new Staticman(req.params)
+  const staticman = new Staticman(req)
+  const captcha = Captcha.create(staticman)
 
   staticman.setConfigPath(createConfigObject(req.params.version, req.params.property))
   staticman.setIp(req.headers['x-forwarded-for'] || req.connection.remoteAddress)
   staticman.setUserAgent(req.headers['user-agent'])
 
-  return checkRecaptcha(staticman, req).then(usedRecaptcha => {
+  return captcha.checkRecaptcha(req).then(usedRecaptcha => {
     return process(staticman, req, res)
   }).catch(err => {
     return sendResponse(res, {
       error: err,
-      errorCode: 'RECAPTCHA_ERROR',
+      errorCode: 'PROCESSING_ERROR',
       redirect: req.body.options.redirect,
       redirectError: req.body.options.redirectError
     })

--- a/lib/Captcha.js
+++ b/lib/Captcha.js
@@ -12,47 +12,62 @@ class Captcha {
     return new Captcha(staticman, reCaptcha)
   }
 
-  validateRequest(req) {
+  checkRecaptcha(req) {
     return new Promise((resolve, reject) => {
-      this.staticman.getSiteConfig()
-        .then(siteConfig => {
-          let captchaRequest
+      this.staticman.getSiteConfig().then(siteConfig => {
+        if (!siteConfig.get('reCaptcha.enabled')) {
+          return resolve(false)
+        }
 
-          if (!siteConfig.get('reCaptcha.enabled')) {
-            return resolve()
+        const reCaptchaOptions = req.body.options && req.body.options.reCaptcha
+
+        if (!reCaptchaOptions || !reCaptchaOptions.siteKey || !reCaptchaOptions.secret) {
+          return reject('Missing reCAPTCHA API credentials')
+        }
+
+        let decryptedSecret
+
+        try {
+          decryptedSecret = this.staticman.decrypt(reCaptchaOptions.secret)
+        } catch (err) {
+          return reject('Could not decrypt reCAPTCHA secret')
+        }
+
+        if ((reCaptchaOptions.siteKey) !== siteConfig.get('reCaptcha.siteKey') ||
+          (decryptedSecret !== siteConfig.get('reCaptcha.secret'))) {
+          return reject('reCAPTCHA options do not match Staticman config')
+        }
+
+        reCaptcha.init(reCaptchaOptions.siteKey, decryptedSecret)
+        reCaptcha.verify(req, err => {
+          if (err) {
+            return reject(this.getRecaptchaError(err))
           }
 
-          if(!req.body.options.reCaptcha  || !req.body.options.reCaptcha.siteKey  ||  !req.body.options.reCaptcha.encryptedSecret) {
-            return reject('Missing reCAPTCHA API credential.')
-          }
-
-          try {
-            captchaRequest = {
-              siteKey: req.body.options.reCaptcha.siteKey,
-              secret: this.staticman.decrypt(req.body.options.reCaptcha.encryptedSecret)
-            }
-          } catch(err) {
-            return reject('Invalid encryptedSecret')
-          }
-
-          if(siteConfig.get('reCaptcha.siteKey') !== captchaRequest.siteKey  || siteConfig.get('reCaptcha.secret') !== captchaRequest.secret) {
-            return reject('ReCAPTCHA API credential spoofing is not allowed.')
-          }
-
-          this.reCaptcha.init(captchaRequest.siteKey, captchaRequest.secret)
-
-          this.reCaptcha.verify(req, (err) => {
-            if (err) {
-              return reject(err)
-            }
-            return resolve()
-          })
+          return resolve(true)
         })
-        .catch(err => {
-          return reject(err)
-        })
+      }).catch(err => reject(err))
     })
   }
+
+  getRecaptchaError(errorCode) {
+    switch (errorCode) {
+      case 'missing-input-secret':
+        return 'reCAPTCHA: The secret parameter is missing'
+
+      case 'invalid-input-secret':
+        return 'reCAPTCHA: The secret parameter is invalid or malformed'
+
+      case 'missing-input-response':
+        return 'reCAPTCHA: The response parameter is missing'
+
+      case 'invalid-input-response':
+        return 'reCAPTCHA: The response parameter is invalid or malformed'
+    }
+
+    return errorCode
+  }
+
 }
 
 module.exports = Captcha

--- a/lib/Captcha.js
+++ b/lib/Captcha.js
@@ -1,0 +1,58 @@
+'use strict'
+const reCaptcha = require('express-recaptcha')
+
+class Captcha {
+
+  constructor(staticman, reCaptcha) {
+    this.staticman = staticman
+    this.reCaptcha = reCaptcha
+  }
+
+  static create(staticman) {
+    return new Captcha(staticman, reCaptcha)
+  }
+
+  validateRequest(req) {
+    return new Promise((resolve, reject) => {
+      this.staticman.getSiteConfig()
+        .then(siteConfig => {
+          let captchaRequest
+
+          if (!siteConfig.get('reCaptcha.enabled')) {
+            return resolve()
+          }
+
+          if(!req.body.options.reCaptcha  || !req.body.options.reCaptcha.siteKey  ||  !req.body.options.reCaptcha.encryptedSecret) {
+            return reject('Missing reCAPTCHA API credential.')
+          }
+
+          try {
+            captchaRequest = {
+              siteKey: req.body.options.reCaptcha.siteKey,
+              secret: this.staticman.decrypt(req.body.options.reCaptcha.encryptedSecret)
+            }
+          } catch(err) {
+            return reject('Invalid encryptedSecret')
+          }
+
+          if(siteConfig.get('reCaptcha.siteKey') !== captchaRequest.siteKey  || siteConfig.get('reCaptcha.secret') !== captchaRequest.secret) {
+            return reject('ReCAPTCHA API credential spoofing is not allowed.')
+          }
+
+          this.reCaptcha.init(captchaRequest.siteKey, captchaRequest.secret)
+
+          this.reCaptcha.verify(req, (err) => {
+            if (err) {
+              return reject(err)
+            }
+            return resolve()
+          })
+        })
+        .catch(err => {
+          return reject(err)
+        })
+    })
+  }
+}
+
+module.exports = Captcha

--- a/lib/Staticman.js
+++ b/lib/Staticman.js
@@ -15,8 +15,8 @@ const yaml = require('js-yaml')
 
 const Staticman = function (req) {
   this.parameters = req.params
-  this.fields = req.query.fields || req.body.fields || {}
-  this.options = req.query.options || req.body.options || {}
+  this.fields = Object.assign( {}, req.query.fields, req.body.fields)
+  this.options = Object.assign( {}, req.query.options, req.body.options)
 
   // Initialise GitHub API
   this.github = new GitHub({
@@ -64,8 +64,8 @@ Staticman.prototype._applyGeneratedFields = function (data) {
           break
 
         case 'slugify':
-          if (typeof options.field === 'string') {
-            data[field] = slugify(data[options.field]).toLowerCase()
+          if (typeof this.options.field === 'string') {
+            data[field] = slugify(data[this.options.field]).toLowerCase()
           }
 
           break
@@ -434,7 +434,7 @@ Staticman.prototype.decrypt = function (encrypted) {
 
 Staticman.prototype.processEntry = function () {
   return this.getSiteConfig().then(config => {
-    return this._checkForSpam(fields)
+    return this._checkForSpam(this.fields)
   }).then(fields => {
     // Validate fields
     const fieldErrors = this._validateFields(fields)
@@ -452,7 +452,9 @@ Staticman.prototype.processEntry = function () {
     // Create file
     return this._createFile(extendedFields)
   }).then(data => {
-    const filePath = this._getNewFilePath(fields)
+    const fields = this.fields
+    const options = this.options
+    const filePath = this._getNewFilePath(this.fields)
     const subscriptions = this._initialiseSubscriptions()
     const commitMessage = this._resolvePlaceholders(this.siteConfig.get('commitMessage'), {
       fields,
@@ -460,8 +462,8 @@ Staticman.prototype.processEntry = function () {
     })
 
     // Subscribe user, if applicable
-    if (subscriptions && options.parent && options.subscribe && this.fields[options.subscribe]) {
-      subscriptions.set(options.parent, this.fields[options.subscribe]).catch(err => {
+    if (subscriptions && options.parent && options.subscribe && fields[options.subscribe]) {
+      subscriptions.set(options.parent, fields[options.subscribe]).catch(err => {
         console.log(err.stack || err)
       })
     }
@@ -477,8 +479,8 @@ Staticman.prototype.processEntry = function () {
     return this.github.writeFile(filePath, data, this.parameters.branch, commitMessage)
   }).then(result => {
     return {
-      fields: fields,
-      redirect: options.redirect ? options.redirect : false
+      fields: this.fields,
+      redirect: this.options.redirect ? this.options.redirect : false
     }
   })
 }
@@ -490,7 +492,7 @@ Staticman.prototype.processMerge = function (fields, options) {
   return this.getSiteConfig().then(config => {
     const subscriptions = this._initialiseSubscriptions()
 
-    return subscriptions.send(options.parent, fields, options, this.siteConfig)
+    return subscriptions.send(this.options.parent, fields, options, this.siteConfig)
   })
 }
 

--- a/lib/Staticman.js
+++ b/lib/Staticman.js
@@ -13,8 +13,10 @@ const SubscriptionsManager = require('./SubscriptionsManager')
 const uuid = require('node-uuid')
 const yaml = require('js-yaml')
 
-const Staticman = function (parameters) {
-  this.parameters = parameters
+const Staticman = function (req) {
+  this.parameters = req.params
+  this.fields = req.query.fields || req.body.fields || {}
+  this.options = req.query.options || req.body.options || {}
 
   // Initialise GitHub API
   this.github = new GitHub({
@@ -222,7 +224,13 @@ Staticman.prototype._getConfig = function (force) {
 
   return this.github.readFile(this.configPath.file).then(data => {
     const config = objectPath.get(data, this.configPath.path)
-    const validationErrors = this._validateConfig(config)
+    let validationErrors
+
+    try {
+      validationErrors = this._validateConfig(config)
+    } catch (e) {
+      return Promise.reject(`Config validation failed:\n${e.stack}`)
+    }
 
     if (validationErrors) {
       return Promise.reject(validationErrors)
@@ -415,9 +423,7 @@ Staticman.prototype._validateFields = function (fields) {
   return null
 }
 
-Staticman.prototype.processEntry = function (fields, options) {
-  this.fields = Object.assign({}, fields)
-  this.options = Object.assign({}, options)
+Staticman.prototype.processEntry = function () {
 
   return this._getConfig().then(config => {
     return this._checkForSpam(fields)


### PR DESCRIPTION
Bug related to the `origin` and `allowed origin` has been fixed.
It was related to the way of the instantiation of the `Staticman` in the `process.js`
As a new `Staticman` instance is used for every request, I moved the `req.fields` and `req.options` to the constructor of `Staticman`.

Also moved the functions related to the reCaptcha validation to a separate file in order to improve readability and maintainability.