### PR TITLE
Add spinningnumbers.org to list of sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ Parameters used to configure a site can be found [here](https://staticman.net/do
 - [movw-0x16.cf](http://movw-0x16.cf/) ([Source](https://github.com/twentytwoo/movw-0x16))
 - [Open Source Design Job Board](http://opensourcedesign.net/jobs/) ([Source](https://github.com/opensourcedesign/jobs/))
 - [zongren.me](https://zongren.me/) ([Source](https://gitlab.com/zongren/zongren.gitlab.io/)) 
-- [DOTSLASHLINUX](http://www.dotslashlinux.com/) ([Source](https://github.com/firasuke/DOTSLASHLINUX/)) 
+- [DOTSLASHLINUX](http://www.dotslashlinux.com/) ([Source](https://github.com/firasuke/DOTSLASHLINUX/))
+- [Spinningnumbers.org](http://spinningnumbers.org/) ([Source](https://github.com/willymcallister/spinningnumbers)
 
 
 Are you using Staticman? [Let us know!](https://github.com/eduardoboucas/staticman/edit/master/README.md)


### PR DESCRIPTION
Spinningnumbers.org is based on the default minima theme provided by github pages/Jekyll. I'm currently using unmoderated comments, recapcha for spam reduction, and do not ask for a commenter's email address.