### PR TITLE
Added missing parameter this.siteConfig when calling subscriptions.send

### DIFF
--- a/lib/Staticman.js
+++ b/lib/Staticman.js
@@ -441,7 +441,7 @@ Staticman.prototype.processEntry = function (fields, options) {
 
       return this.github.writeFileAndSendPR(filePath, data, newBranch, commitMessage, this._generatePRBody(fields))
     } else if (subscriptions && options.parent) {
-      subscriptions.send(options.parent, fields, options)
+      subscriptions.send(options.parent, fields, options, this.siteConfig)
     }
 
     return this.github.writeFile(filePath, data, this.parameters.branch, commitMessage)


### PR DESCRIPTION
Greetings!

In an attempt to debug issues with getting mail notifications for comments to work i was able to get it working by adding a (missing?) parameter when calling subscriptions.send which will fix an issue with siteConfig being undefined in the send function of the subscription module.

Applying this fix makes mail notifications work immediately with my local install of staticman (using my own malign account).

Please check and merge, if my assumptions are correct and this is a fix.

Regards,
Andreas