### PR TITLE
Update a file on repository if it already exists

### DIFF
--- a/lib/GitHub.js
+++ b/lib/GitHub.js
@@ -87,7 +87,7 @@ GitHub.prototype.writeFile = function (filePath, data, branch, commitTitle) {
     message: commitTitle,
     branch: branch
   }
-  var readFileResponse = this.readFile(filePath, true);
+  var readFileResponse = this.readFile(filePath, true)
 
   return readFileResponse.then(r => {
     // If the file exists, get its sha and send an update request.
@@ -101,7 +101,7 @@ GitHub.prototype.writeFile = function (filePath, data, branch, commitTitle) {
     return this.api.repos.createFile(requestData).catch(err => {
       return Promise.reject(errorHandler('GITHUB_WRITING_FILE', {err}))
     })
-  });
+  })
 
 }
 

--- a/lib/GitHub.js
+++ b/lib/GitHub.js
@@ -54,6 +54,7 @@ GitHub.prototype.readFile = function (path, getFullResponse) {
 
       return getFullResponse ? {
         content: content,
+        sha: res.sha,
         file: {
           content: res.content
         }
@@ -70,24 +71,38 @@ GitHub.prototype.readFile = function (path, getFullResponse) {
       return Promise.reject(errorHandler('PARSING_ERROR', errorData))
     }
   }).catch(err => {
-    return Promise.reject(errorHandler('GITHUB_READING_FILE', {err}))
+    return Promise.reject(errorHandler('GITHUB_READING_FILE', err))
   })
 }
 
 GitHub.prototype.writeFile = function (filePath, data, branch, commitTitle) {
   branch = branch || this.options.branch
   commitTitle = commitTitle || 'Add Staticman file'
-
-  return this.api.repos.createFile({
+  var content = Buffer.from(data).toString('base64')
+  var requestData = {
     user: this.options.username,
     repo: this.options.repository,
     path: filePath,
-    content: Buffer.from(data).toString('base64'),
+    content: content,
     message: commitTitle,
     branch: branch
+  }
+  var readFileResponse = this.readFile(filePath, true);
+
+  return readFileResponse.then(r => {
+    // If the file exists, get its sha and send an update request.
+    requestData['sha'] = r.sha
+
+    return this.api.repos.updateFile(requestData).catch(err => {
+      return Promise.reject(errorHandler('GITHUB_UPDATING_FILE', {err}))
+    })
   }).catch(err => {
-    return Promise.reject(errorHandler('GITHUB_WRITING_FILE', {err}))
-  })
+    // If new file doesn't previously exists, create it on the repository.
+    return this.api.repos.createFile(requestData).catch(err => {
+      return Promise.reject(errorHandler('GITHUB_WRITING_FILE', {err}))
+    })
+  });
+
 }
 
 GitHub.prototype.writeFileAndSendPR = function (filePath, data, branch, commitTitle, commitBody) {


### PR DESCRIPTION
Check if the file that Staticman is going to create on the repository already exist. If it exists, instead of using createFile from Github lib, get the sha of the existing file and send an updateFile request.

# Motivation

We are currently using Staticman for the comments on the http://edulabs.de website. We want to make it possible for the users to suggest new projects for the area edulabs.de/projects, and give to them the possibility of editing it after the project is approved. Each project is going to be a simple markdown file, that is already being created using Staticman. The problem is that when the project file already exist, we would like to create a new pull request updating the file content, instead of creating a new file. This pull request implements this feature.