### PR TITLE
Upgrade js-yaml to 3.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "express-github-webhook": "^1.0.5",
     "express-recaptcha": "^2.1.0",
     "github": "^3.0.0",
-    "js-yaml": "^3.6.1",
+    "js-yaml": "^3.10.0",
     "mailgun-js": "^0.7.13",
     "markdown-table": "^1.0.0",
     "md5": "^2.1.0",


### PR DESCRIPTION
If you put an emoji in a staticman comment, that'll trigger nodeca/js-yaml#368 which will make js-yaml output yaml that cannot be parsed by Jekyll, thus causing the website build to fail. The bug was fixed in 3.10.0.