### PR TITLE
AMP headers (continued)

### DIFF
--- a/server.js
+++ b/server.js
@@ -38,7 +38,7 @@ StaticmanAPI.prototype.initialiseBruteforceProtection = function () {
 
 StaticmanAPI.prototype.initialiseCORS = function () {
   this.server.use((req, res, next) => {
-    res.header('Access-Control-Allow-Origin', '*')
+    res.header('Access-Control-Allow-Origin', req.headers.origin || '*')
     res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
 
     next()


### PR DESCRIPTION
It turns out that when the AMP doc says:

> Although the W3 CORS spec allows the value of `*` to be returned in the response, for improved security, you should validate and echo the value of the `"Origin"` header.

What they mean is: you **must** validate and echo the value of the `"Origin"` header.

Currently the feature doesn't work. I don't see any reason for this change to be a problem for other setups, especially since I keep the fallback wildcard value. Hopefully this is the last missing part.