### PR TITLE
More HTTP headers

### DIFF
--- a/server.js
+++ b/server.js
@@ -40,6 +40,8 @@ StaticmanAPI.prototype.initialiseCORS = function () {
   this.server.use((req, res, next) => {
     res.header('Access-Control-Allow-Origin', '*')
     res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
+    res.header('Access-Control-Allow-Credentials', 'true')
+    res.header('Access-Control-Allow-Methods', 'GET, POST')
 
     next()
   })


### PR DESCRIPTION
Still not working. I'm sorry but this is really poorly documented and I'm not the only one saying it, see https://github.com/ampproject/amphtml/issues/12089.

The good news is this allowed me to see [how the AMP team does it themselves](https://github.com/ampproject/amphtml/blob/ee2dea74e954ceaf5c284bfbfb2f81416858fa9a/build-system/test-server.js#L26), and it looks we're on the right track!

Right now it's complaining very specificly about the `credentials` header: `The value of the 'Access-Control-Allow-Credentials' header in the response is '' which must be 'true' when the request's credentials mode is 'include'.`

But let's also add `methods` to be on the safe side.

In case you're wondering, `credentials` is forced to to true by AMP, for security reasons. So I can't disable it from the client side.