### PR TITLE
AMP headers upfront

### DIFF
--- a/controllers/process.js
+++ b/controllers/process.js
@@ -71,8 +71,7 @@ function process (staticman, req, res) {
   return staticman.processEntry(fields, options).then(data => {
     sendResponse(res, {
       redirect: data.redirect,
-      fields: data.fields,
-      ampSourceOrigin: req.query.__amp_source_origin
+      fields: data.fields
     })
 
     if (ua) {
@@ -81,8 +80,7 @@ function process (staticman, req, res) {
   }).catch(err => {
     sendResponse(res, {
       err: errorHandler('UNKNOWN_ERROR', {err}),
-      redirectError: req.body.options && req.body.options.redirectError,
-      ampSourceOrigin: req.query.__amp_source_origin
+      redirectError: req.body.options && req.body.options.redirectError
     })
 
     if (ua) {
@@ -96,11 +94,6 @@ function process (staticman, req, res) {
 function sendResponse (res, data) {
   const error = data && data.err
   const statusCode = error ? 500 : 200
-
-  if (data && data.ampSourceOrigin) {
-    res.header('AMP-Access-Control-Allow-Source-Origin', data.ampSourceOrigin)
-    res.header('Access-Control-Expose-Headers', 'AMP-Access-Control-Allow-Source-Origin')
-  }
 
   if (!error && data.redirect) {
     return res.redirect(data.redirect)
@@ -148,8 +141,7 @@ module.exports = (req, res, next) => {
     return sendResponse(res, {
       err,
       redirect: req.body.options && req.body.options.redirect,
-      redirectError: req.body.options && req.body.options.redirectError,
-      ampSourceOrigin: req.query.__amp_source_origin
+      redirectError: req.body.options && req.body.options.redirectError
     })
   })
 }

--- a/server.js
+++ b/server.js
@@ -43,6 +43,11 @@ StaticmanAPI.prototype.initialiseCORS = function () {
     res.header('Access-Control-Allow-Credentials', 'true')
     res.header('Access-Control-Allow-Methods', 'GET, POST')
 
+    if (req.query.__amp_source_origin) {
+      res.header('AMP-Access-Control-Allow-Source-Origin', req.query.__amp_source_origin)
+      res.header('Access-Control-Expose-Headers', 'AMP-Access-Control-Allow-Source-Origin')
+    }
+
     next()
   })
 }

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -101,13 +101,11 @@ module.exports.getMockResponse = () => {
   const statusFn = jest.fn(code => ({
     send: sendFn
   }))
-  const headerFn = jest.fn()
 
   return {
     redirect: redirectFn,
     send: sendFn,
-    status: statusFn,
-    header: headerFn
+    status: statusFn
   }
 }
 

--- a/test/unit/controllers/process.test.js
+++ b/test/unit/controllers/process.test.js
@@ -505,40 +505,5 @@ describe('Process controller', () => {
       expect(res.status.mock.calls.length).toBe(1)
       expect(res.status.mock.calls[0][0]).toBe(500)
     })
-
-    test('no AMP headers with regular requests', () => {
-      const data = {
-        fields: {
-          name: 'Eduardo Bouças',
-          email: 'mail@eduardoboucas.com'
-        }
-      }
-
-      const res = mockHelpers.getMockResponse()
-
-      sendResponse(res, data)
-
-      expect(res.header.mock.calls.length).toBe(0)
-    })
-
-    test('AMP headers if ampSourceOrigin is defined (by req.query.__amp_source_origin)', () => {
-      const data = {
-        ampSourceOrigin: 'https://eduardoboucas.com',
-        fields: {
-          name: 'Eduardo Bouças',
-          email: 'mail@eduardoboucas.com'
-        }
-      }
-
-      const res = mockHelpers.getMockResponse()
-
-      sendResponse(res, data)
-
-      expect(res.header.mock.calls.length).toBe(2)
-      expect(res.header.mock.calls[0][0]).toBe('AMP-Access-Control-Allow-Source-Origin')
-      expect(res.header.mock.calls[0][1]).toBe('https://eduardoboucas.com')
-      expect(res.header.mock.calls[1][0]).toBe('Access-Control-Expose-Headers')
-      expect(res.header.mock.calls[1][1]).toBe('AMP-Access-Control-Allow-Source-Origin')
-    })
   })
 })


### PR DESCRIPTION
I now get the headers I added to `server.js`, but not those in `process.js`. This isn't my area of expertise but I'm afraid it might be too late to send headers at that point.

Let's do it upfront like in this example: https://github.com/ampproject/amphtml/blob/ee2dea74e954ceaf5c284bfbfb2f81416858fa9a/build-system/test-server.js#L26

Headers make more sense in the same place anyway. Sorry for the back and forth but I don't know how to run this locally, and I've never debugged JS anyway.