### PR TITLE
Add downcase/upcase and multiple transform support

### DIFF
--- a/lib/Staticman.js
+++ b/lib/Staticman.js
@@ -7,7 +7,6 @@ const errorHandler = require('./ErrorHandler')
 const GitHub = require('./GitHub')
 const markdownTable = require('markdown-table')
 const moment = require('moment')
-const md5 = require('md5')
 const Mailgun = require('mailgun-js')
 const NodeRSA = require('node-rsa')
 const objectPath = require('object-path')
@@ -15,6 +14,7 @@ const RSA = require('./RSA')
 const SiteConfig = require(path.join(__dirname, '/../siteConfig'))
 const slugify = require('slug')
 const SubscriptionsManager = require('./SubscriptionsManager')
+const Transforms = require('./Transforms')
 const uuid = require('node-uuid')
 const yaml = require('js-yaml')
 
@@ -35,6 +35,8 @@ const Staticman = function (parameters) {
   this.rsa = new NodeRSA()
   this.rsa.importKey(config.get('rsaPrivateKey'))
 }
+
+Staticman.prototype._transforms = Transforms
 
 Staticman.prototype._applyInternalFields = function (data) {
   let internalFields = {
@@ -103,8 +105,10 @@ Staticman.prototype._applyTransforms = function (fields) {
   Object.keys(transforms).forEach(field => {
     if (!fields[field]) return
 
-    if (transforms[field] === 'md5') {
-      fields[field] = md5(fields[field])
+    let transformFn = this._transforms[transforms[field]]
+
+    if (transformFn) {
+      fields[field] = transformFn(fields[field])
     }
   })
 

--- a/lib/Staticman.js
+++ b/lib/Staticman.js
@@ -105,11 +105,14 @@ Staticman.prototype._applyTransforms = function (fields) {
   Object.keys(transforms).forEach(field => {
     if (!fields[field]) return
 
-    let transformFn = this._transforms[transforms[field]]
+    let transformNames = [].concat(transforms[field])
 
-    if (transformFn) {
-      fields[field] = transformFn(fields[field])
-    }
+    transformNames.forEach(transformName => {
+      let transformFn = this._transforms[transformName]
+      if (transformFn) {
+        fields[field] = transformFn(fields[field])
+      }
+    })
   })
 
   return Promise.all(queue).then((results) => {

--- a/lib/Transforms.js
+++ b/lib/Transforms.js
@@ -3,3 +3,7 @@ const md5 = require('md5')
 exports.md5 = function md5Transform (value) {
   return md5(value)
 }
+
+exports.upcase = function upcaseTransform (value) {
+  return String(value).toUpperCase()
+}

--- a/lib/Transforms.js
+++ b/lib/Transforms.js
@@ -7,3 +7,7 @@ exports.md5 = function md5Transform (value) {
 exports.upcase = function upcaseTransform (value) {
   return String(value).toUpperCase()
 }
+
+exports.downcase = function downcaseTransform (value) {
+  return String(value).toLowerCase()
+}

--- a/lib/Transforms.js
+++ b/lib/Transforms.js
@@ -1,0 +1,5 @@
+const md5 = require('md5')
+
+exports.md5 = function md5Transform (value) {
+  return md5(value)
+}

--- a/test/unit/lib/Staticman.test.js
+++ b/test/unit/lib/Staticman.test.js
@@ -230,6 +230,29 @@ describe('Staticman interface', () => {
         expect(transformedData).toEqual(extendedData)
       })
     })
+
+    test('handles multiple transforms per field', () => {
+      const Staticman = require('./../../../lib/Staticman')
+      const staticman = new Staticman(mockParameters)
+
+      mockConfig.set('transforms', {
+        email: ['testTransform1', 'testTransform2']
+      })
+      staticman.siteConfig = mockConfig
+      staticman._transforms = {
+        testTransform1() { return 'transformed:1' },
+        testTransform2(v) { return `${v}-transformed:2` },
+      }
+
+      const data = mockHelpers.getFields()
+      const extendedData = Object.assign({}, data, {
+        email: 'transformed:1-transformed:2'
+      })
+
+      return staticman._applyTransforms(data).then(transformedData => {
+        expect(transformedData).toEqual(extendedData)
+      })
+    })
   })
 
   describe('spam detection', () => {

--- a/test/unit/lib/Staticman.test.js
+++ b/test/unit/lib/Staticman.test.js
@@ -211,13 +211,19 @@ describe('Staticman interface', () => {
       const staticman = new Staticman(mockParameters)
 
       mockConfig.set('transforms', {
-        email: 'md5'
+        name: 'testTransformName',
+        email: 'testTransformEmail'
       })
       staticman.siteConfig = mockConfig
+      staticman._transforms = {
+        testTransformName() { return 'transformed-name' },
+        testTransformEmail() { return 'transformed-email' }
+      }
 
       const data = mockHelpers.getFields()
       const extendedData = Object.assign({}, data, {
-        email: md5(data.email)
+        name: 'transformed-name',
+        email: 'transformed-email'
       })
 
       return staticman._applyTransforms(data).then(transformedData => {

--- a/test/unit/lib/Transforms.test.js
+++ b/test/unit/lib/Transforms.test.js
@@ -6,4 +6,10 @@ describe('Transforms', () => {
       expect(Transforms.md5('test-value')).toEqual('83b3c112b82dcca8376da029e8101bcc');
     })
   })
+
+  describe('upcase', () => {
+    test('returns an upcased value', () => {
+      expect(Transforms.upcase('foobar')).toEqual('FOOBAR')
+    })
+  })
 })

--- a/test/unit/lib/Transforms.test.js
+++ b/test/unit/lib/Transforms.test.js
@@ -12,4 +12,10 @@ describe('Transforms', () => {
       expect(Transforms.upcase('foobar')).toEqual('FOOBAR')
     })
   })
+
+  describe('downcase', () => {
+    test('returns an downcased value', () => {
+      expect(Transforms.downcase('FOOBAR')).toEqual('foobar')
+    })
+  })
 })

--- a/test/unit/lib/Transforms.test.js
+++ b/test/unit/lib/Transforms.test.js
@@ -1,0 +1,9 @@
+const Transforms = require('./../../../lib/Transforms')
+
+describe('Transforms', () => {
+  describe('md5', () => {
+    test('returns an MD5 of the value', () => {
+      expect(Transforms.md5('test-value')).toEqual('83b3c112b82dcca8376da029e8101bcc');
+    })
+  })
+})


### PR DESCRIPTION
Closes #74

I had to remove the `.only` to perform the tests on the new feature because of commit 8678e9d ("test: fix tests", 2017-11-21) but that cause unrelated tests to fail. I left the `.only` as is in the PR. CI will unfortunately skip the tests in this PR because of that. But I did check to make sure the tests I added/changed did work locally before pushing.