### PR TITLE
Add log between _checkForSpam and _validateFields

### DIFF
--- a/lib/Staticman.js
+++ b/lib/Staticman.js
@@ -466,6 +466,17 @@ Staticman.prototype.processEntry = function (fields, options) {
   }).then(() => {
     return this._checkForSpam(fields)
   }).then(fields => {
+    // Log what `fields` looks like at this point - trying to fix #176
+    logger.info(
+      JSON.stringify({
+        requestId,
+        stage: '_checkForSpam',
+        fields,
+      }),
+      null,
+      2
+    )
+
     // Validate fields
     const fieldErrors = this._validateFields(fields)
 
@@ -473,7 +484,7 @@ Staticman.prototype.processEntry = function (fields, options) {
     logger.info(
       JSON.stringify({
         requestId,
-        stage: '_checkForSpam',
+        stage: '_validateFields',
         fields,
       }),
       null,


### PR DESCRIPTION
Progress! I found the error. It's happening somewhere in the beginning, either `_checkForSpam` or `_validateFields`. This change should tell us which.

I only saw the error after enabling akismet for my site, so my suspicion is that it's related to akismet.