### PR TITLE
Bump convict version to 4.3.0. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "akismet": "^1.0.0",
     "body-parser": "^1.17.x",
     "bunyan-slack": "0.0.10",
-    "convict": "^1.5.0",
+    "convict": "^4.3.0",
     "express": "^4.14.0",
     "express-brute": "^0.6.0",
     "express-github-webhook": "^1.0.5",


### PR DESCRIPTION
Turns out the solution was simple!

Fixes #176