### PR TITLE
Bug #218, respond with 4xx HTTP error codes, not 500

### DIFF
--- a/controllers/process.js
+++ b/controllers/process.js
@@ -82,7 +82,7 @@ function process (staticman, req, res) {
 
 function sendResponse (res, data) {
   const error = data && data.err
-  const statusCode = error ? 500 : 200
+  const statusCode = errorHandler.getInstance().getHttpStatus(error)
 
   if (!error && data.redirect) {
     return res.redirect(data.redirect)

--- a/lib/ErrorHandler.js
+++ b/lib/ErrorHandler.js
@@ -22,11 +22,11 @@ const ErrorHandler = function () {
   }
 
   this.HTTP_STATUS = {
-    'missing-input-secret': 404,
+    'missing-input-secret': 400,
     'invalid-input-secret': 400,
-    'missing-input-response': 404,
+    'missing-input-response': 400,
     'invalid-input-response': 400,
-    'RECAPTCHA_MISSING_CREDENTIALS': 404,
+    'RECAPTCHA_MISSING_CREDENTIALS': 400,
     'RECAPTCHA_FAILED_DECRYPT': 400,
     'RECAPTCHA_CONFIG_MISMATCH': 400,
     'PARSING_ERROR': 400,

--- a/lib/ErrorHandler.js
+++ b/lib/ErrorHandler.js
@@ -20,6 +20,19 @@ const ErrorHandler = function () {
     'missing-input-response': 'RECAPTCHA_MISSING_INPUT_RESPONSE',
     'invalid-input-response': 'RECAPTCHA_INVALID_INPUT_RESPONSE'
   }
+
+  this.HTTP_STATUS = {
+    'missing-input-secret': 404,
+    'invalid-input-secret': 400,
+    'missing-input-response': 404,
+    'invalid-input-response': 400,
+    'RECAPTCHA_MISSING_CREDENTIALS': 404,
+    'RECAPTCHA_FAILED_DECRYPT': 400,
+    'RECAPTCHA_CONFIG_MISMATCH': 400,
+    'PARSING_ERROR': 400,
+    'GITHUB_AUTH_TOKEN_MISSING': 400,
+    'MISSING_CONFIG_FIELDS': 400
+  }
 }
 
 ErrorHandler.prototype.getErrorCode = function (error) {
@@ -28,6 +41,18 @@ ErrorHandler.prototype.getErrorCode = function (error) {
 
 ErrorHandler.prototype.getMessage = function (error) {
   return this.ERROR_MESSAGES[error]
+}
+
+ErrorHandler.prototype.getHttpStatus = function (error) {
+  let statusCode = 200
+  if (error && error.code && /^[2345]\d\d$/.error.code) {
+    statusCode = parseInt(error.code)
+  } else if (error && error._smErrorCode) {
+    statusCode = this.HTTP_STATUS[error._smErrorCode]
+  } else if (error) {
+    statusCode = 500
+  }
+  return statusCode
 }
 
 ErrorHandler.prototype.log = function (err, instance) {

--- a/test/unit/controllers/process.test.js
+++ b/test/unit/controllers/process.test.js
@@ -201,7 +201,7 @@ describe('Process controller', () => {
           decrypt: mockHelpers.decrypt,
           getSiteConfig: () => Promise.resolve(mockSiteConfig)
         }))
-      })    
+      })
 
       const checkRecaptcha = require('./../../../controllers/process').checkRecaptcha
       const Staticman = require('./../../../lib/Staticman')
@@ -479,7 +479,7 @@ describe('Process controller', () => {
       expect(res.status.mock.calls[0][0]).toBe(200)
     })
 
-    test('sends a 500 with an error object if there is an error', () => {
+    test('sends a 4XX with an error object if there is an error', () => {
       const data = {
         err: {
           _smErrorCode: 'missing-input-secret'
@@ -500,7 +500,7 @@ describe('Process controller', () => {
         errorHandler.getErrorCode(data.err._smErrorCode)
       )
       expect(res.status.mock.calls.length).toBe(1)
-      expect(res.status.mock.calls[0][0]).toBe(500)
+      expect(res.status.mock.calls[0][0]).toBe(404)
     })
   })
 })

--- a/test/unit/controllers/process.test.js
+++ b/test/unit/controllers/process.test.js
@@ -500,7 +500,7 @@ describe('Process controller', () => {
         errorHandler.getErrorCode(data.err._smErrorCode)
       )
       expect(res.status.mock.calls.length).toBe(1)
-      expect(res.status.mock.calls[0][0]).toBe(404)
+      expect(res.status.mock.calls[0][0]).toBe(400)
     })
   })
 })


### PR DESCRIPTION
Hi @eduardoboucas,

I've implemented a fix/enhancement for the #218 issue.

You'll see that it uses several sources to try to determine the HTTP status code — `payload.rawError.code`, then `payload.rawError._smErrorCode`.

The possible HTTP status codes are:

 * `404` — REST purists may not agree with how I propose using this for "_missing_" config-type errors (some/all of these could be changed to `400` I  suppose);
 * `403` — one of the GitHub responses I think (https://github.com/nfreear/nfreear.github.io/issues/32#issuecomment-405286416);
 * `400` — most of the "_invalid_" request/ config-type responses;
 * (`500` — _fallback, unknown error_)
 * `200` — success;

I hope this helps.

Best wishes,


Nick