### PR TITLE
Use referer for redirect

### DIFF
--- a/controllers/process.js
+++ b/controllers/process.js
@@ -68,6 +68,8 @@ function process (staticman, req, res) {
   const fields = req.query.fields || req.body.fields
   const options = req.query.options || req.body.options || {}
 
+  options.referer = req.headers.referer
+
   return staticman.processEntry(fields, options).then(data => {
     sendResponse(res, {
       redirect: data.redirect,

--- a/lib/Staticman.js
+++ b/lib/Staticman.js
@@ -513,9 +513,11 @@ Staticman.prototype.processEntry = function (fields, options) {
       commitMessage
     )
   }).then(result => {
+    let referer = this.siteConfig.get("referer")
+    let redirect = (referer.enabled && options.referer)? options.referer+referer.postfix : options.redirect || false
     return {
       fields: fields,
-      redirect: options.redirect ? options.redirect : false
+      redirect: redirect
     }
   }).catch(err => {
     return Promise.reject(errorHandler('ERROR_PROCESSING_ENTRY', {

--- a/siteConfig.js
+++ b/siteConfig.js
@@ -156,6 +156,18 @@ const schema = {
       format: 'EncryptedString',
       default: ''
     }
+  },
+  referer: {
+    enabled: {
+      doc: 'Set to `true` to enable redirect back to referer page',
+      format: Boolean,
+      default: false
+    },
+    postfix: {
+      doc: 'Append this string to the referer to build the redirect adress',
+      format: String,
+      default: ''
+    }
   }
 }
 


### PR DESCRIPTION
If no options.redirect is given, try using the referer of the request
for the redirect to the original page.

Make referer redirect configurable in staticman.yml (including "postfix" option to add postfix to referer before redirecting).