### PR TITLE
Add a new site running Staticman v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,5 +105,6 @@ Would you like to contribute to Staticman? That's great! Here's how:
 - [Gatsby Central](https://www.gatsbycentral.com) ([Source](https://github.com/GatsbyCentral/gatsbycentral.com))
 - [Minimal Hugo GitLab Pages running on Staticman v3](https://vincenttam.gitlab.io/test-hugo-staticman) ([Source](https://gitlab.com/VincentTam/test-hugo-staticman))
 - [Minimal Jekyll GitHub Pages running on Staticman v3](https://git.io/smdemo) ([Source](https://github.com/VincentTam/TestStaticmanLab))
+- [Ultima IV—Advent of the Trinity](https://cambragol.github.io/ultima-IV-trinity/articles/first-post) ([Source](https://github.com/cambragol/ultima-IV-trinity))
 
 Are you using Staticman? [Let us know!](https://github.com/eduardoboucas/staticman/edit/master/README.md)

--- a/README.md
+++ b/README.md
@@ -104,5 +104,6 @@ Would you like to contribute to Staticman? That's great! Here's how:
 - [La ruta de la cebada](https://larutadelacebada.com) ([Source](https://github.com/lasocial/larutadelacebada.github.io))
 - [Gatsby Central](https://www.gatsbycentral.com) ([Source](https://github.com/GatsbyCentral/gatsbycentral.com))
 - [Minimal Hugo GitLab Pages running on Staticman v3](https://vincenttam.gitlab.io/test-hugo-staticman) ([Source](https://gitlab.com/VincentTam/test-hugo-staticman))
+- [Minimal Jekyll GitHub Pages running on Staticman v3](https://git.io/smdemo) ([Source](https://github.com/VincentTam/TestStaticmanLab))
 
 Are you using Staticman? [Let us know!](https://github.com/eduardoboucas/staticman/edit/master/README.md)

--- a/README.md
+++ b/README.md
@@ -103,5 +103,6 @@ Would you like to contribute to Staticman? That's great! Here's how:
 - [BinaryMist](https://binarymist.io/blog) ([Source](https://github.com/binarymist/BinaryMistBlog))
 - [La ruta de la cebada](https://larutadelacebada.com) ([Source](https://github.com/lasocial/larutadelacebada.github.io))
 - [Gatsby Central](https://www.gatsbycentral.com) ([Source](https://github.com/GatsbyCentral/gatsbycentral.com))
+- [Minimal Hugo GitLab Pages running on Staticman v3](https://vincenttam.gitlab.io/test-hugo-staticman) ([Source](https://gitlab.com/VincentTam/test-hugo-staticman))
 
 Are you using Staticman? [Let us know!](https://github.com/eduardoboucas/staticman/edit/master/README.md)


### PR DESCRIPTION
Thanks to #219 , I have managed to build a [Hugo site with _native GitLab support_](https://vincenttam.gitlab.io/test-hugo-staticman/posts/test-staticman/).  At the [request](https://github.com/eduardoboucas/staticman/pull/219#issuecomment-417657297) of @eduardoboucas , I've created my instance of the API on https://staticman3.herokuapp.com/.

The source code for my own API instance on Heroku is available on VincentTam@dd1969c