### PR TITLE
Add the DevKami to the list of sites using s-man

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,5 +103,6 @@ Would you like to contribute to Staticman? That's great! Here's how:
 - [BinaryMist](https://binarymist.io/blog) ([Source](https://github.com/binarymist/BinaryMistBlog))
 - [La ruta de la cebada](https://larutadelacebada.com) ([Source](https://github.com/lasocial/larutadelacebada.github.io))
 - [Gatsby Central](https://www.gatsbycentral.com) ([Source](https://github.com/GatsbyCentral/gatsbycentral.com))
+- [DevKami Meetups Submission](https://devkami.com/page/meetups/) ([Source](https://github.com/devxkami/devkami.com))
 
 Are you using Staticman? [Let us know!](https://github.com/eduardoboucas/staticman/edit/master/README.md)


### PR DESCRIPTION
DevKami uses staticman to crowdsource meetups data. We use Hugo and the data template functionality to make it really easy to submit and then review the resulting PR, making it a very smooth workflow.