### PR TITLE
fix: config schema, deprecated GitHub API methods

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -40,7 +40,7 @@ module.exports = (req, res) => {
 
       // TODO: Simplify this when v2 support is dropped.
       const getUser = req.params.version === '2' && req.params.service === 'github'
-        ? git.api.users.get({}).then(({data}) => data)
+        ? git.api.users.getAuthenticated({}).then(({data}) => data)
         : git.getCurrentUser()
 
       return getUser

--- a/coverage/cobertura-coverage.xml
+++ b/coverage/cobertura-coverage.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
-<coverage lines-valid="786" lines-covered="686" line-rate="0.8728" branches-valid="360" branches-covered="278" branch-rate="0.7722" timestamp="1534078804178" complexity="0" version="0.1">
+<coverage lines-valid="786" lines-covered="686" line-rate="0.8728" branches-valid="360" branches-covered="278" branch-rate="0.7722" timestamp="1546183916957" complexity="0" version="0.1">
   <sources>
-    <source>/home/nick/Development/Javascript/staticman</source>
+    <source>C:\Users\Maciek\Workspace\staticman</source>
   </sources>
   <packages>
     <package name="staticman" line-rate="0.8556" branch-rate="0.5">
@@ -191,41 +191,41 @@
           <methods>
             <method name="(anonymous_0)" hits="15" signature="()V">
               <lines>
-                <line number="189" hits="15"/>
+                <line number="195" hits="15"/>
               </lines>
             </method>
             <method name="(anonymous_1)" hits="105" signature="()V">
               <lines>
-                <line number="192" hits="105"/>
+                <line number="198" hits="105"/>
               </lines>
             </method>
             <method name="(anonymous_2)" hits="85" signature="()V">
               <lines>
-                <line number="193" hits="85"/>
+                <line number="199" hits="85"/>
               </lines>
             </method>
           </methods>
           <lines>
             <line number="3" hits="84" branch="false"/>
             <line number="5" hits="84" branch="false"/>
-            <line number="189" hits="84" branch="false"/>
-            <line number="190" hits="15" branch="false"/>
-            <line number="192" hits="105" branch="false"/>
-            <line number="194" hits="85" branch="false"/>
-            <line number="198" hits="15" branch="false"/>
-            <line number="200" hits="15" branch="false"/>
-            <line number="201" hits="15" branch="false"/>
-            <line number="202" hits="15" branch="false"/>
+            <line number="195" hits="84" branch="false"/>
+            <line number="196" hits="15" branch="false"/>
+            <line number="198" hits="105" branch="false"/>
+            <line number="200" hits="85" branch="false"/>
             <line number="204" hits="15" branch="false"/>
-            <line number="206" hits="0" branch="false"/>
-            <line number="210" hits="84" branch="false"/>
+            <line number="206" hits="15" branch="false"/>
+            <line number="207" hits="15" branch="false"/>
+            <line number="208" hits="15" branch="false"/>
+            <line number="210" hits="15" branch="false"/>
+            <line number="212" hits="0" branch="false"/>
+            <line number="216" hits="84" branch="false"/>
           </lines>
         </class>
       </classes>
     </package>
     <package name="staticman.controllers" line-rate="0.9281" branch-rate="0.8265">
       <classes>
-        <class name="auth.js" filename="controllers/auth.js" line-rate="1" branch-rate="0.875">
+        <class name="auth.js" filename="controllers\auth.js" line-rate="1" branch-rate="0.875">
           <methods>
             <method name="(anonymous_0)" hits="7" signature="()V">
               <lines>
@@ -288,7 +288,7 @@
             <line number="59" hits="4" branch="false"/>
           </lines>
         </class>
-        <class name="connect.js" filename="controllers/connect.js" line-rate="0.9048" branch-rate="0.7">
+        <class name="connect.js" filename="controllers\connect.js" line-rate="0.9048" branch-rate="0.7">
           <methods>
             <method name="(anonymous_0)" hits="3" signature="()V">
               <lines>
@@ -340,7 +340,7 @@
             <line number="47" hits="0" branch="false"/>
           </lines>
         </class>
-        <class name="encrypt.js" filename="controllers/encrypt.js" line-rate="0.8571" branch-rate="0.5">
+        <class name="encrypt.js" filename="controllers\encrypt.js" line-rate="0.8571" branch-rate="0.5">
           <methods>
             <method name="(anonymous_0)" hits="1" signature="()V">
               <lines>
@@ -358,7 +358,7 @@
             <line number="13" hits="1" branch="false"/>
           </lines>
         </class>
-        <class name="handlePR.js" filename="controllers/handlePR.js" line-rate="0.871" branch-rate="0.7273000000000001">
+        <class name="handlePR.js" filename="controllers\handlePR.js" line-rate="0.871" branch-rate="0.7273000000000001">
           <methods>
             <method name="(anonymous_0)" hits="4" signature="()V">
               <lines>
@@ -420,7 +420,7 @@
             <line number="62" hits="1" branch="false"/>
           </lines>
         </class>
-        <class name="home.js" filename="controllers/home.js" line-rate="0.6667000000000001" branch-rate="1">
+        <class name="home.js" filename="controllers\home.js" line-rate="0.6667000000000001" branch-rate="1">
           <methods>
             <method name="(anonymous_0)" hits="0" signature="()V">
               <lines>
@@ -434,7 +434,7 @@
             <line number="6" hits="0" branch="false"/>
           </lines>
         </class>
-        <class name="process.js" filename="controllers/process.js" line-rate="0.9565" branch-rate="0.8929">
+        <class name="process.js" filename="controllers\process.js" line-rate="0.9565" branch-rate="0.8929">
           <methods>
             <method name="checkRecaptcha" hits="12" signature="()V">
               <lines>
@@ -573,7 +573,7 @@
     </package>
     <package name="staticman.lib" line-rate="0.8519" branch-rate="0.7602">
       <classes>
-        <class name="ErrorHandler.js" filename="lib/ErrorHandler.js" line-rate="0.8158" branch-rate="0.8">
+        <class name="ErrorHandler.js" filename="lib\ErrorHandler.js" line-rate="0.8158" branch-rate="0.8">
           <methods>
             <method name="(anonymous_0)" hits="4" signature="()V">
               <lines>
@@ -662,7 +662,7 @@
             <line number="107" hits="134" branch="false"/>
           </lines>
         </class>
-        <class name="GitHub.js" filename="lib/GitHub.js" line-rate="0.925" branch-rate="0.5556">
+        <class name="GitHub.js" filename="lib\GitHub.js" line-rate="0.925" branch-rate="0.5556">
           <methods>
             <method name="(anonymous_0)" hits="20" signature="()V">
               <lines>
@@ -813,7 +813,7 @@
             <line number="163" hits="53" branch="false"/>
           </lines>
         </class>
-        <class name="GitLab.js" filename="lib/GitLab.js" line-rate="0.8649" branch-rate="0.6923">
+        <class name="GitLab.js" filename="lib\GitLab.js" line-rate="0.8649" branch-rate="0.6923">
           <methods>
             <method name="(anonymous_0)" hits="24" signature="()V">
               <lines>
@@ -961,7 +961,7 @@
             <line number="118" hits="47" branch="false"/>
           </lines>
         </class>
-        <class name="GitService.js" filename="lib/GitService.js" line-rate="0.7576" branch-rate="0.7273000000000001">
+        <class name="GitService.js" filename="lib\GitService.js" line-rate="0.7576" branch-rate="0.7273000000000001">
           <methods>
             <method name="(anonymous_0)" hits="85" signature="()V">
               <lines>
@@ -1080,7 +1080,7 @@
             <line number="97" hits="72" branch="false"/>
           </lines>
         </class>
-        <class name="GitServiceFactory.js" filename="lib/GitServiceFactory.js" line-rate="1" branch-rate="1">
+        <class name="GitServiceFactory.js" filename="lib\GitServiceFactory.js" line-rate="1" branch-rate="1">
           <methods>
             <method name="(anonymous_0)" hits="99" signature="()V">
               <lines>
@@ -1097,7 +1097,7 @@
             <line number="11" hits="91" branch="false"/>
           </lines>
         </class>
-        <class name="Logger.js" filename="lib/Logger.js" line-rate="0" branch-rate="0">
+        <class name="Logger.js" filename="lib\Logger.js" line-rate="0" branch-rate="0">
           <methods>
             <method name="(anonymous_0)" hits="0" signature="()V">
               <lines>
@@ -1133,7 +1133,7 @@
             <line number="34" hits="0" branch="false"/>
           </lines>
         </class>
-        <class name="Notification.js" filename="lib/Notification.js" line-rate="0.7857" branch-rate="0.375">
+        <class name="Notification.js" filename="lib\Notification.js" line-rate="0.7857" branch-rate="0.375">
           <methods>
             <method name="(anonymous_0)" hits="2" signature="()V">
               <lines>
@@ -1178,7 +1178,7 @@
             <line number="46" hits="75" branch="false"/>
           </lines>
         </class>
-        <class name="OAuth.js" filename="lib/OAuth.js" line-rate="1" branch-rate="1">
+        <class name="OAuth.js" filename="lib\OAuth.js" line-rate="1" branch-rate="1">
           <methods>
             <method name="(anonymous_0)" hits="5" signature="()V">
               <lines>
@@ -1226,7 +1226,7 @@
             <line number="46" hits="3" branch="false"/>
           </lines>
         </class>
-        <class name="RSA.js" filename="lib/RSA.js" line-rate="0.9286" branch-rate="1">
+        <class name="RSA.js" filename="lib\RSA.js" line-rate="0.9286" branch-rate="1">
           <methods>
             <method name="(anonymous_0)" hits="4" signature="()V">
               <lines>
@@ -1256,7 +1256,7 @@
             <line number="22" hits="3" branch="false"/>
           </lines>
         </class>
-        <class name="Staticman.js" filename="lib/Staticman.js" line-rate="0.9765" branch-rate="0.9257">
+        <class name="Staticman.js" filename="lib\Staticman.js" line-rate="0.9765" branch-rate="0.9257">
           <methods>
             <method name="(anonymous_0)" hits="88" signature="()V">
               <lines>
@@ -1772,7 +1772,7 @@
             <line number="607" hits="77" branch="false"/>
           </lines>
         </class>
-        <class name="SubscriptionsManager.js" filename="lib/SubscriptionsManager.js" line-rate="0.2895" branch-rate="0">
+        <class name="SubscriptionsManager.js" filename="lib\SubscriptionsManager.js" line-rate="0.2895" branch-rate="0">
           <methods>
             <method name="(anonymous_0)" hits="1" signature="()V">
               <lines>
@@ -1886,7 +1886,7 @@
             <line number="81" hits="74" branch="false"/>
           </lines>
         </class>
-        <class name="Transforms.js" filename="lib/Transforms.js" line-rate="1" branch-rate="1">
+        <class name="Transforms.js" filename="lib\Transforms.js" line-rate="1" branch-rate="1">
           <methods>
             <method name="md5Transform" hits="6" signature="()V">
               <lines>
@@ -1914,7 +1914,7 @@
             <line number="12" hits="1" branch="false"/>
           </lines>
         </class>
-        <class name="TypeUtils.js" filename="lib/TypeUtils.js" line-rate="0.75" branch-rate="0.6667000000000001">
+        <class name="TypeUtils.js" filename="lib\TypeUtils.js" line-rate="0.75" branch-rate="0.6667000000000001">
           <methods>
             <method name="(anonymous_0)" hits="132" signature="()V">
               <lines>
@@ -1933,7 +1933,7 @@
     </package>
     <package name="staticman.lib.models" line-rate="1" branch-rate="1">
       <classes>
-        <class name="Review.js" filename="lib/models/Review.js" line-rate="1" branch-rate="1">
+        <class name="Review.js" filename="lib\models\Review.js" line-rate="1" branch-rate="1">
           <methods>
             <method name="(anonymous_0)" hits="4" signature="()V">
               <lines>
@@ -1956,7 +1956,7 @@
             <line number="28" hits="72" branch="false"/>
           </lines>
         </class>
-        <class name="User.js" filename="lib/models/User.js" line-rate="1" branch-rate="1">
+        <class name="User.js" filename="lib\models\User.js" line-rate="1" branch-rate="1">
           <methods>
             <method name="(anonymous_0)" hits="14" signature="()V">
               <lines>

--- a/lib/GitHub.js
+++ b/lib/GitHub.js
@@ -38,7 +38,7 @@ class GitHub extends GitService {
   }
 
   _pullFile (filePath, branch) {
-    return this.api.repos.getContent({
+    return this.api.repos.getContents({
       owner: this.username,
       repo: this.repository,
       path: filePath,
@@ -151,7 +151,7 @@ class GitHub extends GitService {
   }
 
   getCurrentUser () {
-    return this.api.users.get({})
+    return this.api.users.getAuthenticated({})
       .then(normalizeResponse)
       .then(({login, email, avatar_url, name, bio, company, blog}) =>
         new User('github', login, email, name, avatar_url, bio, blog, company)

--- a/lib/Staticman.js
+++ b/lib/Staticman.js
@@ -198,7 +198,7 @@ Staticman.prototype._checkAuthV2 = function () {
 
   const git = gitFactory.create('github', {oauthToken})
 
-  return git.api.users.get({}).then(({data}) => {
+  return git.api.users.getAuthenticated({}).then(({data}) => {
     this.gitUser = data
     return true
   })

--- a/siteConfig.js
+++ b/siteConfig.js
@@ -9,6 +9,12 @@ const schema = {
     format: Array,
     default: []
   },
+  allowedOrigins: {
+    doc: 'When allowedOrigins is defined, only requests sent from one of the domains listed will be accepted.',
+    docExample: 'allowedOrigins: ["localhost", "eduardoboucas.com"]',
+    default: [],
+    format: Array
+  },
   akismet: {
     enabled: {
       doc: 'Whether to use Akismet to check entries for spam. This requires an Akismet account to be configured in the Staticman API instance being used.',

--- a/test/unit/lib/GitHub.test.js
+++ b/test/unit/lib/GitHub.test.js
@@ -66,7 +66,7 @@ describe('GitHub interface', () => {
     test('reads a file and returns its contents', () => {
       const fileContents = 'This is a text file!'
       const filePath = 'path/to/file.txt'
-      const mockReposGetContent = jest.fn(() => Promise.resolve({
+      const mockReposGetContents = jest.fn(() => Promise.resolve({
         data: {
           content: btoa(fileContents)
         }
@@ -76,7 +76,7 @@ describe('GitHub interface', () => {
         _ => ({
           authenticate: jest.fn(),
           repos: {
-            getContent: mockReposGetContent
+            getContents: mockReposGetContents
           }
         })
       )
@@ -85,7 +85,7 @@ describe('GitHub interface', () => {
       const githubInstance = new GitHub(req.params)
 
       return githubInstance.readFile(filePath).then(contents => {
-        expect(mockReposGetContent.mock.calls[0][0]).toEqual({
+        expect(mockReposGetContents.mock.calls[0][0]).toEqual({
           owner: req.params.username,
           repo: req.params.repository,
           path: filePath,
@@ -96,13 +96,13 @@ describe('GitHub interface', () => {
 
     test('returns an error if GitHub API call errors', () => {
       const filePath = 'path/to/file.yml'
-      const mockReposGetContent = jest.fn(() => Promise.reject()) // eslint-disable-line prefer-promise-reject-errors
+      const mockReposGetContents = jest.fn(() => Promise.reject()) // eslint-disable-line prefer-promise-reject-errors
 
       jest.mock('@octokit/rest', () =>
         _ => ({
           authenticate: jest.fn(),
           repos: {
-            getContent: mockReposGetContent
+            getContents: mockReposGetContents
           }
         })
       )
@@ -111,7 +111,7 @@ describe('GitHub interface', () => {
       const githubInstance = new GitHub(req.params)
 
       return githubInstance.readFile(filePath).catch(err => {
-        expect(mockReposGetContent.mock.calls[0][0]).toEqual({
+        expect(mockReposGetContents.mock.calls[0][0]).toEqual({
           owner: req.params.username,
           repo: req.params.repository,
           path: filePath,
@@ -129,7 +129,7 @@ describe('GitHub interface', () => {
         baz
       `
       const filePath = 'path/to/file.yml'
-      const mockReposGetContent = jest.fn(() => Promise.resolve({
+      const mockReposGetContents = jest.fn(() => Promise.resolve({
         data: {
           content: btoa(fileContents)
         }
@@ -139,7 +139,7 @@ describe('GitHub interface', () => {
         _ => ({
           authenticate: jest.fn(),
           repos: {
-            getContent: mockReposGetContent
+            getContents: mockReposGetContents
           }
         })
       )
@@ -148,7 +148,7 @@ describe('GitHub interface', () => {
       const githubInstance = new GitHub(req.params)
 
       return githubInstance.readFile(filePath).catch(err => {
-        expect(mockReposGetContent.mock.calls[0][0]).toEqual({
+        expect(mockReposGetContents.mock.calls[0][0]).toEqual({
           owner: req.params.username,
           repo: req.params.repository,
           path: filePath,
@@ -162,7 +162,7 @@ describe('GitHub interface', () => {
     test('reads a YAML file and returns its parsed contents', () => {
       const filePath = 'path/to/file.yml'
       const parsedConfig = yaml.safeLoad(sampleData.config1, 'utf8')
-      const mockReposGetContent = jest.fn(() => Promise.resolve({
+      const mockReposGetContents = jest.fn(() => Promise.resolve({
         data: {
           content: btoa(sampleData.config1)
         }
@@ -172,7 +172,7 @@ describe('GitHub interface', () => {
         _ => ({
           authenticate: jest.fn(),
           repos: {
-            getContent: mockReposGetContent
+            getContents: mockReposGetContents
           }
         })
       )
@@ -181,7 +181,7 @@ describe('GitHub interface', () => {
       const githubInstance = new GitHub(req.params)
 
       return githubInstance.readFile(filePath).then(contents => {
-        expect(mockReposGetContent.mock.calls[0][0]).toEqual({
+        expect(mockReposGetContents.mock.calls[0][0]).toEqual({
           owner: req.params.username,
           repo: req.params.repository,
           path: filePath,
@@ -197,7 +197,7 @@ describe('GitHub interface', () => {
         content: btoa(sampleData.config1)
       }
       const filePath = 'path/to/file.yml'
-      const mockReposGetContent = jest.fn(() => Promise.resolve({
+      const mockReposGetContents = jest.fn(() => Promise.resolve({
         data: fileContents
       }))
 
@@ -205,7 +205,7 @@ describe('GitHub interface', () => {
         _ => ({
           authenticate: jest.fn(),
           repos: {
-            getContent: mockReposGetContent
+            getContents: mockReposGetContents
           }
         })
       )
@@ -214,7 +214,7 @@ describe('GitHub interface', () => {
       const githubInstance = new GitHub(req.params)
 
       return githubInstance.readFile(filePath, true).then(response => {
-        expect(mockReposGetContent.mock.calls[0][0]).toEqual({
+        expect(mockReposGetContents.mock.calls[0][0]).toEqual({
           owner: req.params.username,
           repo: req.params.repository,
           path: filePath,
@@ -228,7 +228,7 @@ describe('GitHub interface', () => {
     test('reads a JSON file and returns its parsed contents', () => {
       const filePath = 'path/to/file.json'
       const parsedConfig = yaml.safeLoad(sampleData.config2, 'utf8')
-      const mockReposGetContent = jest.fn(() => Promise.resolve({
+      const mockReposGetContents = jest.fn(() => Promise.resolve({
         data: {
           content: btoa(sampleData.config2)
         }
@@ -238,7 +238,7 @@ describe('GitHub interface', () => {
         _ => ({
           authenticate: jest.fn(),
           repos: {
-            getContent: mockReposGetContent
+            getContents: mockReposGetContents
           }
         })
       )
@@ -247,7 +247,7 @@ describe('GitHub interface', () => {
       const githubInstance = new GitHub(req.params)
 
       return githubInstance.readFile(filePath).then(contents => {
-        expect(mockReposGetContent.mock.calls[0][0]).toEqual({
+        expect(mockReposGetContents.mock.calls[0][0]).toEqual({
           owner: req.params.username,
           repo: req.params.repository,
           path: filePath,
@@ -263,7 +263,7 @@ describe('GitHub interface', () => {
       }
       const filePath = 'path/to/file.json'
       const parsedConfig = yaml.safeLoad(sampleData.config2, 'utf8')
-      const mockReposGetContent = jest.fn(() => Promise.resolve({
+      const mockReposGetContents = jest.fn(() => Promise.resolve({
         data: fileContents
       }))
 
@@ -271,7 +271,7 @@ describe('GitHub interface', () => {
         _ => ({
           authenticate: jest.fn(),
           repos: {
-            getContent: mockReposGetContent
+            getContents: mockReposGetContents
           }
         })
       )
@@ -280,7 +280,7 @@ describe('GitHub interface', () => {
       const githubInstance = new GitHub(req.params)
 
       return githubInstance.readFile(filePath, true).then(response => {
-        expect(mockReposGetContent.mock.calls[0][0]).toEqual({
+        expect(mockReposGetContents.mock.calls[0][0]).toEqual({
           owner: req.params.username,
           repo: req.params.repository,
           path: filePath,
@@ -531,7 +531,7 @@ describe('GitHub interface', () => {
         _ => ({
           authenticate: jest.fn(),
           users: {
-            get: () => Promise.resolve({data: mockUser})
+            getAuthenticated: () => Promise.resolve({data: mockUser})
           }
         })
       )
@@ -549,7 +549,7 @@ describe('GitHub interface', () => {
         _ => ({
           authenticate: jest.fn(),
           users: {
-            get: () => Promise.reject()
+            getAuthenticated: () => Promise.reject()
           }
         })
       )

--- a/test/unit/lib/Staticman.test.js
+++ b/test/unit/lib/Staticman.test.js
@@ -720,7 +720,7 @@ describe('Staticman interface', () => {
           return {
             api: {
               users: {
-                get: mockGetCurrentUser
+                getAuthenticated: mockGetCurrentUser
               }
             }
           }


### PR DESCRIPTION
fixed convict complaining about `allowedOrigins` not being defined in the schema and GitHub API deprecated `users.get` and `repos.getContent` methods.