### PR TITLE
feature: mailgun eu region api support

### DIFF
--- a/config.js
+++ b/config.js
@@ -35,6 +35,12 @@ const schema = {
       default: null,
       env: 'EMAIL_API_KEY'
     },
+    apiHost: {
+      doc: 'Mailgun API host URL to be used for email notifications. Will be overridden by a `notifications.apiHost` parameter in the site config, if one is set.',
+      format: String,
+      default: 'api.mailgun.net',
+      env: 'EMAIL_API_HOST'
+    },
     domain: {
       doc: 'Domain to be used with Mailgun for email notifications. Will be overridden by a `notifications.domain` parameter in the site config, if one is set.',
       format: String,

--- a/lib/Staticman.js
+++ b/lib/Staticman.js
@@ -352,6 +352,7 @@ Staticman.prototype._initialiseSubscriptions = function () {
   // Initialise Mailgun
   const mailgun = Mailgun({
     apiKey: this.siteConfig.get('notifications.apiKey') || config.get('email.apiKey'),
+    host: this.siteConfig.get('notifications.apiHost') || config.get('email.apiHost'),
     domain: this.siteConfig.get('notifications.domain') || config.get('email.domain')
   })
 

--- a/siteConfig.js
+++ b/siteConfig.js
@@ -146,6 +146,11 @@ const schema = {
       format: 'EncryptedString',
       default: null
     },
+    apiHost: {
+      doc: 'Mailgun API host',
+      format: String,
+      default: 'api.mailgun.net'
+    },
     domain: {
       doc: 'Mailgun domain',
       format: 'EncryptedString',

--- a/staticman.sample.yml
+++ b/staticman.sample.yml
@@ -52,6 +52,9 @@ comments:
     # Enable notifications
     #enabled: true
 
+    # Mailgun API host URL. If in EU-Region, use 'api.eu.mailgun.net'
+    #apiHost: "api.mailgun.net"
+
     # (!) ENCRYPTED
     #
     # Mailgun API key


### PR DESCRIPTION
I'm new to Node.js, so this needs some review. It's supposed to tackle #274.
I added an _apiHost_ option that sets the _host_ option in the **mailgun object constructor**.

The `npm test` unfortunately fails at a line I didn't even touch:
`\lib\Staticman.js:508:3: Expected an assignment or function call and instead saw an expression.`
line in question: `this._initialiseGit`

I touched:
* config.js
* lib/Staticman.js
* siteConfig.js
* staticman.sample.yml