### PR TITLE
Allow configuration of listening host

### DIFF
--- a/config.js
+++ b/config.js
@@ -102,6 +102,12 @@ const schema = {
     default: null,
     env: 'GITLAB_TOKEN'
   },
+  host: {
+    doc: 'The host to bind the application to.',
+    format: String,
+    default: null,
+    env: 'HOST'
+  },
   port: {
     doc: 'The port to bind the application to.',
     format: 'port',

--- a/index.js
+++ b/index.js
@@ -2,6 +2,6 @@ const StaticmanAPI = require('./server')
 
 const api = new StaticmanAPI()
 
-api.start(port => {
-  console.log('Staticman API running on port', port)
+api.start((port, host) => {
+  console.log('Staticman API running on', host ? 'host ' + host : '', 'port', port)
 })

--- a/lib/Staticman.js
+++ b/lib/Staticman.js
@@ -34,7 +34,7 @@ const Staticman = function (parameters) {
     repository,
     username,
     version
-  })  
+  })
 
   // Generate unique id
   this.uid = uuidv1()
@@ -503,8 +503,6 @@ Staticman.prototype.getSiteConfig = function (force) {
 Staticman.prototype.processEntry = function (fields, options) {
   this.fields = Object.assign({}, fields)
   this.options = Object.assign({}, options)
-
-  this._initialiseGit
 
   return this.getSiteConfig().then(config => {
     return this._checkAuth()

--- a/server.js
+++ b/server.js
@@ -172,9 +172,9 @@ StaticmanAPI.prototype.requireParams = function (params) {
 }
 
 StaticmanAPI.prototype.start = function (callback) {
-  this.instance = this.server.listen(config.get('port'), () => {
+  this.instance = this.server.listen(config.get('port'), config.get('host'), () => {
     if (typeof callback === 'function') {
-      callback(config.get('port'))
+      callback(config.get('port'), config.get('host'))
     }
   })
 }


### PR DESCRIPTION
I setup staticman on my own server and wasn't able to change the host it is listening to. I only want staticman to listen on localhost, because nginx will be used as reverse-proxy so that I can do https easily.

Does this make sense to you?
After this is merged I can create a PR for the website too.

I also fixed two errors in lib/Staticman.js