### PR TITLE
Multiline field markdowntable for Staticman v3

### DIFF
--- a/lib/Staticman.js
+++ b/lib/Staticman.js
@@ -277,7 +277,9 @@ Staticman.prototype._generateReviewBody = function (fields) {
   ]
 
   Object.keys(fields).forEach(field => {
-    table.push([field, fields[field]])
+    let field_value = fields[field]
+    field_value = typeof field_value === 'string' ? field_value.replace(/\r\n/g,'<br>') : field_value
+    table.push([field, field_value])
   })
 
   let message = this.siteConfig.get('pullRequestBody') + markdownTable(table)


### PR DESCRIPTION
Fix #90.  Implements first three commits of eduardoboucas/staticman#289.  No rollback is needed.  See [VincentTam/gl-hugo!6](https://gitlab.com/VincentTam/gl-hugo/merge_requests/6) on GitLab for a working sample.  Big thanks to @BloggerBust for writing the JS code in the linked commit.