### PR TITLE
fix: Return error message for unexpected recaptcha errors

### DIFF
--- a/controllers/process.js
+++ b/controllers/process.js
@@ -113,6 +113,8 @@ function sendResponse (res, data) {
     }
 
     payload.errorCode = errorCode
+  } else if (error) {
+    payload.rawError = data.err.toString()
   } else {
     payload.fields = data.fields
   }


### PR DESCRIPTION
PR to help address issue #108 by returning an error message for unexpected ReCaptcha errors.