### PR TITLE
Fixed webhook for PR merge handle when moderation is enabled

### DIFF
--- a/controllers/handlePR.js
+++ b/controllers/handlePR.js
@@ -7,7 +7,9 @@ const Staticman = require('../lib/Staticman')
 module.exports = (repo, data) => {
   const ua = config.get('analytics.uaTrackingId')
     ? require('universal-analytics')(config.get('analytics.uaTrackingId'))
-    : null
+    : null;
+
+  data = JSON.parse(data.payload);
 
   if (!data.number) {
     return

--- a/lib/GitHub.js
+++ b/lib/GitHub.js
@@ -24,21 +24,20 @@ class GitHub extends GitService {
     })
 
     const isAppAuth = config.get('githubAppID') &&
-      config.get('githubPrivateKey')
-    const isLegacyAuth = config.get('githubToken') &&
-      ['1', '2'].includes(options.version)
+      config.get('githubPrivateKey');
+    const isLegacyAuth = config.get('githubToken');
 
     this.authentication = Promise.resolve()
 
-    if (options.oauthToken) {
-      this.api.authenticate({
-        type: 'oauth',
-        token: options.oauthToken
-      })
-    } else if (isLegacyAuth) {
+    if (isLegacyAuth) {
       this.api.authenticate({
         type: 'token',
         token: config.get('githubToken')
+      })
+    } else if (options.oauthToken) {
+      this.api.authenticate({
+        type: 'oauth',
+        token: options.oauthToken
       })
     } else if (isAppAuth) {
       this.authentication = this._authenticate(


### PR DESCRIPTION
When I was trying to implement moderation enabled and added the webhook for github, it was throwing error. I could not find the PR number from [data](https://github.com/eduardoboucas/staticman/blob/master/controllers/handlePR.js#L12). From the logs I was able to determine that it is getting a json with `payload: "//pr related json in string"`. So I have used JSON.parse to get the json data out of it.

Finally, I have implemented legacy auth token system, for that I was getting error [Require an `oauthToken` or `token` option](https://github.com/eduardoboucas/staticman/blob/master/lib/GitHub.js#L49). Which was also fixed. And I have removed `&&
      ['1', '2'].includes(options.version)` from [this line](https://github.com/eduardoboucas/staticman/blob/master/lib/GitHub.js#L28) as it was throwing error with PR merging issue(it does not send options.version value when PR merge webhook triggers).