### PR TITLE
improve spam/recaptcha handling

### DIFF
--- a/lib/Staticman.js
+++ b/lib/Staticman.js
@@ -149,6 +149,9 @@ class Staticman {
         comment_author_url: fields[this.siteConfig.get('akismet.authorUrl')],
         comment_content: fields[this.siteConfig.get('akismet.content')]
       }, (err, isSpam) => {
+        if (err || isSpam)
+          console.log('akismet rejected comment:'+JSON.stringify({'err': err, 'isSpam':isSpam, 'fields': fields}))
+
         if (err) return reject(err)
 
         if (isSpam) return reject(errorHandler('IS_SPAM'))


### PR DESCRIPTION
I enjoy using staticman in my site (kitabi.eu), and initially I used it without spam protection, but it became quickly too annoying.
I added reCaptcha and akismet, but I found the need to share the secret recaptcha key in the form field disturbing, as it should not be needed.
So I changed it in the patch along with

* logging of failures
* avoid sending secret (even if encrypted)
* verify origin (to avoid replay attacks)

The original code forces one to share his secret though the site.
I see no advantage in doing this, the secret is already available in the site configuration, and it is easy to get for an attacker if shared in the fields, so the extra security gain is minimal, indeed it is potentially a decrease in security (even if encrypted) because the configuration might be in a private repo, and thus hidden.

I can remove the extra logging or reformat the patch if wanted.