### PR TITLE
Fix RSA key import

### DIFF
--- a/lib/RSA.js
+++ b/lib/RSA.js
@@ -3,7 +3,7 @@ const config = require(path.join(__dirname, '/../config'))
 const NodeRSA = require('node-rsa')
 const key = new NodeRSA()
 
-key.importKey(config.get('rsaPrivateKey'))
+key.importKey(config.get('rsaPrivateKey'), 'private')
 
 module.exports.encrypt = text => {
   try {


### PR DESCRIPTION
It seems this import argument got missed previously. I'm not sure why this was working previously, but this error appears to have started to cause issues deploying to Heroku lately. I discovered this while attempting to deploy fresh to Heroku while troubleshooting #332. I'd like to merge this into dev and then test it a bit and merge it into master shortly after.