### PR TITLE
Alexwaibel clarify setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ You can download and run the Staticman API on your own infrastructure. The easie
 - A [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) for the GitHub account you want to run Staticman with
 - An SSH key (click [here](https://help.github.com/articles/connecting-to-github-with-ssh/) to learn how to create one)
 
-## Setting up the server
+## Setting up the server on your own infrastructure
+NOTE: All you need to do if deploying to Heroku is click the above deploy button and then enter your config variables into Heroku.
 
 - Clone the repository and install the dependencies via npm.
 
@@ -76,5 +77,6 @@ Would you like to contribute to Staticman? That's great! Here's how:
 
 ## Useful links
 
+- [Detailed Staticman Setup Guide](https://travisdowns.github.io/blog/2020/02/05/now-with-comments.html#generate-personal-access-token)
 - [Improving Static Comments with Jekyll & Staticman](https://mademistakes.com/articles/improving-jekyll-static-comments/)
 - [Hugo + Staticman: Nested Replies and E-mail Notifications](https://networkhobo.com/2017/12/30/hugo-staticman-nested-replies-and-e-mail-notifications/)

--- a/index.js
+++ b/index.js
@@ -1,12 +1,10 @@
-(async () => {
-  try {
-    const StaticmanAPI = require('./server')
-    const api = await new StaticmanAPI()
+try {
+  const StaticmanAPI = require('./server')
+  const api = new StaticmanAPI()
 
-    api.start(port => {
-      console.log('Staticman API running on port', port)
-    })
-  } catch (e) {
-    console.error(e)
-  }
-})()
+  api.start(port => {
+    console.log('Staticman API running on port', port)
+  })
+} catch (e) {
+  console.error(e)
+}

--- a/lib/ErrorHandler.js
+++ b/lib/ErrorHandler.js
@@ -27,7 +27,8 @@ const ErrorHandler = function () {
     'RECAPTCHA_FAILED_DECRYPT': 'Could not decrypt reCAPTCHA secret',
     'RECAPTCHA_CONFIG_MISMATCH': 'reCAPTCHA options do not match Staticman config',
     'PARSING_ERROR': 'Error whilst parsing config file',
-    'GITHUB_AUTH_TOKEN_MISSING': 'The site requires a valid GitHub authentication token to be supplied in the `options[github-token]` field'
+    'GITHUB_AUTH_TOKEN_MISSING': 'The site requires a valid GitHub authentication token to be supplied in the `options[github-token]` field',
+    'MISSING_CONFIG_BLOCK': 'Error whilst parsing Staticman config file'
   }
 
   this.ERROR_CODE_ALIASES = {

--- a/lib/GitHub.js
+++ b/lib/GitHub.js
@@ -161,10 +161,10 @@ class GitHub extends GitService {
   }
 
   getReview (reviewId) {
-    return this.api.pullRequests.get({
+    return this.api.pulls.get({
       owner: this.username,
       repo: this.repository,
-      number: reviewId
+      pull_number: reviewId
     })
       .then(normalizeResponse)
       .then(({base, body, head, merged, state, title}) =>

--- a/server.js
+++ b/server.js
@@ -7,30 +7,26 @@ const objectPath = require('object-path')
 
 class StaticmanAPI {
   constructor () {
-    return (async () => {
-      this.controllers = {
-        connect: require('./controllers/connect'),
-        encrypt: require('./controllers/encrypt'),
-        auth: require('./controllers/auth'),
-        handlePR: require('./controllers/handlePR'),
-        home: require('./controllers/home'),
-        process: require('./controllers/process')
-      }
+    this.controllers = {
+      connect: require('./controllers/connect'),
+      encrypt: require('./controllers/encrypt'),
+      auth: require('./controllers/auth'),
+      handlePR: require('./controllers/handlePR'),
+      home: require('./controllers/home'),
+      process: require('./controllers/process')
+    }
 
-      this.server = express()
-      this.server.use(bodyParser.json())
-      this.server.use(bodyParser.urlencoded({
-        extended: true
-        // type: '*'
-      }))
+    this.server = express()
+    this.server.use(bodyParser.json())
+    this.server.use(bodyParser.urlencoded({
+      extended: true
+      // type: '*'
+    }))
 
-      this.initialiseWebhookHandler()
-      this.initialiseCORS()
-      this.initialiseBruteforceProtection()
-      this.initialiseRoutes()
-
-      return this
-    })()
+    this.initialiseWebhookHandler()
+    this.initialiseCORS()
+    this.initialiseBruteforceProtection()
+    this.initialiseRoutes()
   }
 
   initialiseBruteforceProtection () {

--- a/test/acceptance/api.test.js
+++ b/test/acceptance/api.test.js
@@ -1,20 +1,22 @@
-const config = require('./../../config')
+const config = require('../../config')
 const githubToken = config.get('githubToken')
-const helpers = require('./../helpers')
+const helpers = require('../helpers')
 const nock = require('nock')
 const querystring = require('querystring')
 const request = helpers.wrappedRequest
-const sampleData = require('./../helpers/sampleData')
-const StaticmanAPI = require('./../../server')
+const sampleData = require('../helpers/sampleData')
+const StaticmanAPI = require('../../server')
 
 const btoa = contents => Buffer.from(contents).toString('base64')
 
 let server
 
-beforeAll(async (done) => {
-  server = await new StaticmanAPI()
+beforeAll(done => {
+  server = new StaticmanAPI()
 
-  server.start(done)
+  server.start(() => {})
+
+  done()
 })
 
 afterAll(done => {
@@ -206,7 +208,7 @@ describe('Entry endpoint', () => {
     })
   })
 
-  test('outputs a PARSING_ERROR error the site config is malformed', () => {
+  test('outputs a MISSING_CONFIG_BLOCK error the site config is malformed', () => {
     const data = Object.assign({}, helpers.getParameters(), {
       path: 'staticman.yml'
     })
@@ -252,8 +254,8 @@ describe('Entry endpoint', () => {
       const error = JSON.parse(response.error)
 
       expect(error.success).toBe(false)
-      expect(error.errorCode).toBe('PARSING_ERROR')
-      expect(error.message).toBeDefined()
+      expect(error.errorCode).toBe('MISSING_CONFIG_BLOCK')
+      expect(error.message).toBe('Error whilst parsing Staticman config file')
       expect(error.rawError).toBeDefined()
     })
   })

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -10,11 +10,11 @@ const SiteConfig = require('./../../siteConfig')
 const yaml = require('js-yaml')
 
 // Disable console.log() for tests
-// if (process.env.TEST_DEV !== 'true') {
-//   console.debug = console.log
-//   console.log = jest.fn()
-//   console.warn = jest.fn()
-// }
+if (process.env.TEST_DEV !== 'true') {
+  console.debug = console.log
+  console.log = jest.fn()
+  console.warn = jest.fn()
+}
 
 const rsa = new NodeRSA()
 rsa.importKey(config.get('rsaPrivateKey'), 'private')

--- a/test/unit/lib/GitLab.test.js
+++ b/test/unit/lib/GitLab.test.js
@@ -2,6 +2,8 @@ const mockHelpers = require('./../../helpers')
 const sampleData = require('./../../helpers/sampleData')
 const User = require('../../../lib/models/User')
 const yaml = require('js-yaml')
+const GitLab = require('../../../lib/GitLab')
+const config = require('../../../config')
 
 let req
 
@@ -9,6 +11,7 @@ const btoa = contents => Buffer.from(contents).toString('base64')
 
 beforeEach(() => {
   jest.resetModules()
+  jest.restoreAllMocks()
 
   req = mockHelpers.getMockRequest()
   req.params.token = 'test-token'
@@ -16,7 +19,6 @@ beforeEach(() => {
 
 describe('GitLab interface', () => {
   test('initialises the GitLab API wrapper', () => {
-    const GitLab = require('./../../../lib/GitLab')
     const gitlab = new GitLab(req.params)
 
     expect(gitlab.api).toBeDefined()
@@ -33,13 +35,13 @@ describe('GitLab interface', () => {
         }
       }
     })
-
+ 
     const GitLab = require('./../../../lib/GitLab')
     const gitlab = new GitLab(req.params) // eslint-disable-line no-unused-vars
 
     expect(mockConstructor.mock.calls[0][0]).toEqual({
       url: 'https://gitlab.com',
-      token: req.params.token
+      token: 'r4e3w2q1'
     })
   })
 
@@ -67,7 +69,7 @@ describe('GitLab interface', () => {
   })
 
   test('throws error if no personal access token or OAuth token is provided', () => {
-    const GitLab = require('../../../lib/GitLab')
+    jest.spyOn(config, 'get').mockImplementation(() => null)
 
     expect(() => new GitLab({})).toThrowError('Require an `oauthToken` or `token` option')
   })

--- a/test/unit/lib/Staticman.test.js
+++ b/test/unit/lib/Staticman.test.js
@@ -527,11 +527,12 @@ describe('Staticman interface', () => {
       staticman.fields = fields
       staticman.options = options
       staticman.siteConfig = mockConfig
+      staticman.parameters.version = '3'
 
-      return staticman._checkAuth().then((result) => {
-        expect(mockConstructor.mock.calls[1][0]).toEqual({
-          oauthToken: 'test-token'
-        })
+      await staticman._checkAuth()
+      expect(mockConstructor.mock.calls[1][0]).toEqual({
+        oauthToken: 'test-token',
+        version: '3'
       })
     })
 
@@ -559,11 +560,12 @@ describe('Staticman interface', () => {
       staticman.fields = fields
       staticman.options = options
       staticman.siteConfig = mockConfig
+      staticman.parameters.version = '3'
 
-      return staticman._checkAuth().then((result) => {
-        expect(mockConstructor.mock.calls[0][0]).toEqual({
-          oauthToken: 'test-token'
-        })
+      await staticman._checkAuth()
+      expect(mockConstructor.mock.calls[0][0]).toEqual({
+        oauthToken: 'test-token',
+        version: '3'
       })
     })
 
@@ -589,14 +591,14 @@ describe('Staticman interface', () => {
       staticman.fields = fields
       staticman.options = options
       staticman.siteConfig = mockConfig
+      staticman.parameters.version = '3'
 
       const mockUser = new User('github', 'johndoe', 'johndoe@test.com', 'John Doe')
 
-      return staticman._checkAuth().then((result) => {
-        expect(mockGetCurrentUser).toHaveBeenCalledTimes(1)
-        expect(staticman.gitUser).toEqual(mockUser)
-        expect(result).toBeTruthy()
-      })
+      let result = await staticman._checkAuth()
+      expect(mockGetCurrentUser).toHaveBeenCalledTimes(1)
+      expect(staticman.gitUser).toEqual(mockUser)
+      expect(result).toBeTruthy()
     })
 
     test('sets the `gitUser` property to the authenticated User and returns true for GitLab authentication', async () => {
@@ -622,14 +624,14 @@ describe('Staticman interface', () => {
       staticman.fields = fields
       staticman.options = options
       staticman.siteConfig = mockConfig
+      staticman.parameters.version = '3'
 
       const mockUser = new User('github', 'johndoe', 'johndoe@test.com', 'John Doe')
 
-      return staticman._checkAuth().then((result) => {
-        expect(mockGetCurrentUser).toHaveBeenCalledTimes(1)
-        expect(staticman.gitUser).toEqual(mockUser)
-        expect(result).toBeTruthy()
-      })
+      let result = await staticman._checkAuth()
+      expect(mockGetCurrentUser).toHaveBeenCalledTimes(1)
+      expect(staticman.gitUser).toEqual(mockUser)
+      expect(result).toBeTruthy()
     })
   })
 
@@ -1464,16 +1466,16 @@ describe('Staticman interface', () => {
       mockConfig.set('auth.required', true)
 
       staticman.siteConfig = mockConfig
+      staticman.parameters.version = '3'
       staticman._checkForSpam = () => Promise.resolve(fields)
       staticman.git.writeFile = jest.fn(() => Promise.resolve())
 
       const spyCheckAuth = jest.spyOn(staticman, '_checkAuth')
 
-      return staticman.processEntry(fields, options).then(_ => {
-        expect(spyCheckAuth).toHaveBeenCalledTimes(1)
-        expect(mockGetCurrentUser).toHaveBeenCalledTimes(1)
-        expect(staticman.gitUser).toEqual(mockUser)
-      })
+      await staticman.processEntry(fields, options)
+      expect(spyCheckAuth).toHaveBeenCalledTimes(1)
+      expect(mockGetCurrentUser).toHaveBeenCalledTimes(1)
+      expect(staticman.gitUser).toEqual(mockUser)
     })
 
     test('authenticates user before creating file, throwing an error if unable to authenticate', async () => {


### PR DESCRIPTION
Some basic README updates, but hopefully we can reduce deployment confusion this way. I've added a warning detailing that the only steps users must take for Heroku deployment is clicking the button and providing Heroku with their config vars. Additionally, I added an item to the 'Useful Links' section which is a fantastic blog post by @travisdowns which goes into further detail about the entire installation and configuration process.