### PR TITLE
Fix incorrect GitHub library tests

### DIFF
--- a/lib/ErrorHandler.js
+++ b/lib/ErrorHandler.js
@@ -17,81 +17,83 @@ class ApiError {
   }
 }
 
-const ErrorHandler = function () {
-  this.ERROR_MESSAGES = {
-    'missing-input-secret': 'reCAPTCHA: The secret parameter is missing',
-    'invalid-input-secret': 'reCAPTCHA: The secret parameter is invalid or malformed',
-    'missing-input-response': 'reCAPTCHA: The response parameter is missing',
-    'invalid-input-response': 'reCAPTCHA: The response parameter is invalid or malformed',
-    'RECAPTCHA_MISSING_CREDENTIALS': 'Missing reCAPTCHA API credentials',
-    'RECAPTCHA_FAILED_DECRYPT': 'Could not decrypt reCAPTCHA secret',
-    'RECAPTCHA_CONFIG_MISMATCH': 'reCAPTCHA options do not match Staticman config',
-    'PARSING_ERROR': 'Error whilst parsing config file',
-    'GITHUB_AUTH_TOKEN_MISSING': 'The site requires a valid GitHub authentication token to be supplied in the `options[github-token]` field',
-    'MISSING_CONFIG_BLOCK': 'Error whilst parsing Staticman config file'
-  }
-
-  this.ERROR_CODE_ALIASES = {
-    'missing-input-secret': 'RECAPTCHA_MISSING_INPUT_SECRET',
-    'invalid-input-secret': 'RECAPTCHA_INVALID_INPUT_SECRET',
-    'missing-input-response': 'RECAPTCHA_MISSING_INPUT_RESPONSE',
-    'invalid-input-response': 'RECAPTCHA_INVALID_INPUT_RESPONSE'
-  }
-}
-
-ErrorHandler.prototype.getErrorCode = function (error) {
-  return this.ERROR_CODE_ALIASES[error] || error
-}
-
-ErrorHandler.prototype.getMessage = function (error) {
-  return this.ERROR_MESSAGES[error]
-}
-
-ErrorHandler.prototype.log = function (err, instance) {
-  let parameters = {}
-  let prefix = ''
-
-  if (instance) {
-    parameters = instance.getParameters()
-
-    prefix += `${parameters.username}/${parameters.repository}`
-  }
-
-  console.log(`${prefix}`, err)
-}
-
-ErrorHandler.prototype._save = function (errorCode, data = {}) {
-  const {err} = data
-
-  if (err) {
-    err._smErrorCode = err._smErrorCode || errorCode
-
-    // Re-wrap API request errors as these could expose
-    // request/response details that the user should not
-    // be allowed to see e.g. access tokens.
-    // `request-promise` is the primary offender here,
-    // but we similarly do not want others to leak too.
-    if (
-      err instanceof StatusCodeError ||
-      err instanceof RequestError
-    ) {
-      const statusCode = err.statusCode || err.code
-
-      return new ApiError(err.message, statusCode, err._smErrorCode)
+class ErrorHandler {
+  constructor () {
+    this.ERROR_MESSAGES = {
+      'missing-input-secret': 'reCAPTCHA: The secret parameter is missing',
+      'invalid-input-secret': 'reCAPTCHA: The secret parameter is invalid or malformed',
+      'missing-input-response': 'reCAPTCHA: The response parameter is missing',
+      'invalid-input-response': 'reCAPTCHA: The response parameter is invalid or malformed',
+      'RECAPTCHA_MISSING_CREDENTIALS': 'Missing reCAPTCHA API credentials',
+      'RECAPTCHA_FAILED_DECRYPT': 'Could not decrypt reCAPTCHA secret',
+      'RECAPTCHA_CONFIG_MISMATCH': 'reCAPTCHA options do not match Staticman config',
+      'PARSING_ERROR': 'Error whilst parsing config file',
+      'GITHUB_AUTH_TOKEN_MISSING': 'The site requires a valid GitHub authentication token to be supplied in the `options[github-token]` field',
+      'MISSING_CONFIG_BLOCK': 'Error whilst parsing Staticman config file'
     }
 
-    return err
+    this.ERROR_CODE_ALIASES = {
+      'missing-input-secret': 'RECAPTCHA_MISSING_INPUT_SECRET',
+      'invalid-input-secret': 'RECAPTCHA_INVALID_INPUT_SECRET',
+      'missing-input-response': 'RECAPTCHA_MISSING_INPUT_RESPONSE',
+      'invalid-input-response': 'RECAPTCHA_INVALID_INPUT_RESPONSE'
+    }
   }
 
-  let payload = {
-    _smErrorCode: errorCode
+  getErrorCode (error) {
+    return this.ERROR_CODE_ALIASES[error] || error
   }
 
-  if (data.data) {
-    payload.data = data.data
+  getMessage (error) {
+    return this.ERROR_MESSAGES[error]
   }
 
-  return payload
+  log (err, instance) {
+    let parameters = {}
+    let prefix = ''
+
+    if (instance) {
+      parameters = instance.getParameters()
+
+      prefix += `${parameters.username}/${parameters.repository}`
+    }
+
+    console.log(`${prefix}`, err)
+  }
+
+  _save (errorCode, data = {}) {
+    const {err} = data
+
+    if (err) {
+      err._smErrorCode = err._smErrorCode || errorCode
+
+      // Re-wrap API request errors as these could expose
+      // request/response details that the user should not
+      // be allowed to see e.g. access tokens.
+      // `request-promise` is the primary offender here,
+      // but we similarly do not want others to leak too.
+      if (
+        err instanceof StatusCodeError ||
+        err instanceof RequestError
+      ) {
+        const statusCode = err.statusCode || err.code
+
+        return new ApiError(err.message, statusCode, err._smErrorCode)
+      }
+
+      return err
+    }
+
+    let payload = {
+      _smErrorCode: errorCode
+    }
+
+    if (data.data) {
+      payload.data = data.data
+    }
+
+    return payload
+  }
 }
 
 const errorHandler = new ErrorHandler()

--- a/lib/GitHub.js
+++ b/lib/GitHub.js
@@ -117,7 +117,7 @@ class GitHub extends GitService {
           console.log(err)
         }
 
-        return Promise.reject(errorHandler('GITHUB_WRITING_FILE', {err}))
+        return Promise.reject(errorHandler('GITHUB_WRITING_FILE'))
       })
   }
 

--- a/lib/GitHub.js
+++ b/lib/GitHub.js
@@ -182,7 +182,7 @@ class GitHub extends GitService {
     try {
       return await super.readFile(filePath, getFullResponse)
     } catch (err) {
-      return errorHandler('GITHUB_READING_FILE', {err})
+      throw errorHandler('GITHUB_READING_FILE', {err})
     }
   }
 

--- a/lib/GitService.js
+++ b/lib/GitService.js
@@ -51,7 +51,7 @@ class GitService {
     try {
       content = Buffer.from(res.content, 'base64').toString()
     } catch (err) {
-      return errorHandler('GITHUB_READING_FILE', {err})
+      throw errorHandler('GITHUB_READING_FILE', {err})
     }
 
     try {
@@ -85,7 +85,7 @@ class GitService {
         errorData.data = err.message
       }
 
-      return errorHandler('PARSING_ERROR', errorData)
+      throw errorHandler('PARSING_ERROR', errorData)
     }
   }
 

--- a/test/acceptance/api.test.js
+++ b/test/acceptance/api.test.js
@@ -26,7 +26,7 @@ afterAll(done => {
 })
 
 describe('Connect endpoint', () => {
-  test('accepts the invitation if one is found and replies with "OK!"', () => {
+  test('accepts the invitation if one is found and replies with "OK!"', async () => {
     const invitationId = 123
 
     const reqListInvititations = nock('https://api.github.com', {
@@ -52,15 +52,13 @@ describe('Connect endpoint', () => {
       .patch(`/user/repository_invitations/${invitationId}`)
       .reply(204)
 
-    return request('/v2/connect/johndoe/foobar')
-      .then(response => {
-        expect(reqListInvititations.isDone()).toBe(true)
-        expect(reqAcceptInvitation.isDone()).toBe(true)
-        expect(response).toBe('OK!')
-      })
+    let response = await request('/v2/connect/johndoe/foobar')
+    expect(reqListInvititations.isDone()).toBe(true)
+    expect(reqAcceptInvitation.isDone()).toBe(true)
+    expect(response).toBe('OK!')
   })
 
-  test('returns a 404 and an error message if a matching invitation is not found', () => {
+  test('returns a 404 and an error message if a matching invitation is not found', async () => {
     const invitationId = 123
     const reqListInvititations = nock('https://api.github.com', {
       reqheaders: {
@@ -85,18 +83,21 @@ describe('Connect endpoint', () => {
       .patch(`/user/repository_invitations/${invitationId}`)
       .reply(204)
 
-    return request('/v2/connect/johndoe/foobar')
-      .catch(err => {
+    expect.assertions(4)
+
+    try {
+      await request('/v2/connect/johndoe/foobar')
+    } catch (err) {
         expect(reqListInvititations.isDone()).toBe(true)
         expect(reqAcceptInvitation.isDone()).toBe(false)
         expect(err.response.body).toBe('Invitation not found')
         expect(err.statusCode).toBe(404)
-      })
+    }
   })
 })
 
 describe('Entry endpoint', () => {
-  test('outputs a RECAPTCHA_CONFIG_MISMATCH error if reCaptcha options do not match (wrong site key)', () => {
+  test('outputs a RECAPTCHA_CONFIG_MISMATCH error if reCaptcha options do not match (wrong site key)', async () => {
     const data = Object.assign({}, helpers.getParameters(), {
       path: 'staticman.yml'
     })
@@ -136,23 +137,27 @@ describe('Entry endpoint', () => {
     }
     const formData = querystring.stringify(form)
 
-    return request({
-      body: formData,
-      method: 'POST',
-      uri: `/v2/entry/${data.username}/${data.repository}/${data.branch}/${data.property}`,
-      headers: {
-        'content-type': 'application/x-www-form-urlencoded'
-      }
-    }).catch((response) => {
+    expect.assertions(3)
+
+    try {
+      await request({
+        body: formData,
+        method: 'POST',
+        uri: `/v2/entry/${data.username}/${data.repository}/${data.branch}/${data.property}`,
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded'
+        }
+      })
+    } catch(response) {
       const error = JSON.parse(response.error)
 
       expect(error.success).toBe(false)
       expect(error.errorCode).toBe('RECAPTCHA_CONFIG_MISMATCH')
       expect(error.message).toBe('reCAPTCHA options do not match Staticman config')
-    })
+    }
   })
 
-  test('outputs a RECAPTCHA_CONFIG_MISMATCH error if reCaptcha options do not match (wrong secret)', () => {
+  test('outputs a RECAPTCHA_CONFIG_MISMATCH error if reCaptcha options do not match (wrong secret)', async () => {
     const data = Object.assign({}, helpers.getParameters(), {
       path: 'staticman.yml'
     })
@@ -192,23 +197,27 @@ describe('Entry endpoint', () => {
     }
     const formData = querystring.stringify(form)
 
-    return request({
-      body: formData,
-      method: 'POST',
-      uri: '/v2/entry/johndoe/foobar/master/comments',
-      headers: {
-        'content-type': 'application/x-www-form-urlencoded'
-      }
-    }).catch(response => {
+    expect.assertions(3)
+
+    try {
+      await request({
+        body: formData,
+        method: 'POST',
+        uri: '/v2/entry/johndoe/foobar/master/comments',
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded'
+        }
+      })
+    } catch (response) {
       const error = JSON.parse(response.error)
 
       expect(error.success).toBe(false)
       expect(error.errorCode).toBe('RECAPTCHA_CONFIG_MISMATCH')
       expect(error.message).toBe('reCAPTCHA options do not match Staticman config')
-    })
+    }
   })
 
-  test('outputs a MISSING_CONFIG_BLOCK error the site config is malformed', () => {
+  test('outputs a PARSING_ERROR error if the site config is malformed', async () => {
     const data = Object.assign({}, helpers.getParameters(), {
       path: 'staticman.yml'
     })
@@ -243,20 +252,24 @@ describe('Entry endpoint', () => {
     }
     const formData = querystring.stringify(form)
 
-    return request({
-      body: formData,
-      method: 'POST',
-      uri: '/v2/entry/johndoe/foobar/master/comments',
-      headers: {
-        'content-type': 'application/x-www-form-urlencoded'
-      }
-    }).catch(response => {
+    expect.assertions(4)
+
+    try {
+      await request({
+        body: formData,
+        method: 'POST',
+        uri: '/v2/entry/johndoe/foobar/master/comments',
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded'
+        }
+      })
+    } catch (response) {
       const error = JSON.parse(response.error)
 
       expect(error.success).toBe(false)
-      expect(error.errorCode).toBe('MISSING_CONFIG_BLOCK')
-      expect(error.message).toBe('Error whilst parsing Staticman config file')
+      expect(error.errorCode).toBe('PARSING_ERROR')
+      expect(error.message).toBe('Error whilst parsing config file')
       expect(error.rawError).toBeDefined()
-    })
+    }
   })
 })

--- a/test/helpers/sampleData.js
+++ b/test/helpers/sampleData.js
@@ -150,6 +150,13 @@ module.exports.config3 = `comments:
     siteKey: "123456789"
     secret: "@reCaptchaSecret@"`
 
+module.exports.configInvalidYML = `invalid:
+- x
+y
+    foo
+bar
+`
+
 module.exports.prBody1 = `Dear human,
 
 Here's a new entry for your approval. :tada:

--- a/test/unit/lib/GitHub.test.js
+++ b/test/unit/lib/GitHub.test.js
@@ -314,7 +314,7 @@ describe('GitHub interface', () => {
         }
       })
         .put('/repos/johndoe/foobar/contents/path/to/file.txt')
-        .reply(400, {message: "Some error"})
+        .replyWithError('An error')
 
       const githubInstance = await new GitHub(req.params)
 

--- a/test/unit/lib/GitHub.test.js
+++ b/test/unit/lib/GitHub.test.js
@@ -300,7 +300,7 @@ describe('GitHub interface', () => {
       expect(scope.isDone()).toBe(true)
     })
 
-    test.only('returns an error object if the save operation fails', async () => {
+    test('returns an error object if the save operation fails', async () => {
       const options = {
         branch: 'master',
         commitTitle: 'Adds a new file',

--- a/test/unit/lib/GitHub.test.js
+++ b/test/unit/lib/GitHub.test.js
@@ -100,6 +100,8 @@ describe('GitHub interface', () => {
 
       const githubInstance = await new GitHub(req.params)
 
+      expect.assertions(2)
+
       try {
         await githubInstance.readFile(filePath)
       } catch (err) {
@@ -109,17 +111,45 @@ describe('GitHub interface', () => {
       expect(scope.isDone()).toBe(true)
     })
 
-    test('returns an error if parsing fails for the given file', async () => {
+    test('returns an error if the config file cannot be read', async () => {
       const filePath = 'path/to/file.yml'
       const githubInstance = await new GitHub(req.params)
+
+      expect.assertions(2)
 
       try {
         await githubInstance.readFile(filePath)
       } catch (err) {
-        expect(err._smErrorCode).toEqual('PARSING_ERROR')
+        expect(err._smErrorCode).toEqual('GITHUB_READING_FILE')
         expect(err.message).toBeDefined()
       }
     })
+
+    test('returns an error if the config file cannot be parsed', async () => {
+        const scope = nock((/api\.github\.com/), {
+          reqheaders: {
+            authorization: 'token '.concat('1q2w3e4r')
+          }
+        })
+          .get('/repos/johndoe/foobar/contents/path/to/file.yml?ref=master')
+          .reply(200, {
+            content: btoa(sampleData.configInvalidYML)
+          })
+
+        const filePath = 'path/to/file.yml'
+        const githubInstance = await new GitHub(req.params)
+
+        expect.assertions(3)
+
+        try {
+          await githubInstance.readFile(filePath)
+        } catch (err) {
+          expect(err._smErrorCode).toEqual('PARSING_ERROR')
+          expect(err.message).toBeDefined()
+        }
+
+        expect(scope.isDone()).toBe(true)
+      })
 
     test('reads a YAML file and returns its parsed contents', async () => {
       const filePath = 'path/to/file.yml'
@@ -270,7 +300,7 @@ describe('GitHub interface', () => {
       expect(scope.isDone()).toBe(true)
     })
 
-    test('returns an error object if the save operation fails', async () => {
+    test.only('returns an error object if the save operation fails', async () => {
       const options = {
         branch: 'master',
         commitTitle: 'Adds a new file',
@@ -284,11 +314,11 @@ describe('GitHub interface', () => {
         }
       })
         .put('/repos/johndoe/foobar/contents/path/to/file.txt')
-        .reply(200, {
-          number: 123
-        })
+        .reply(400, {message: "Some error"})
 
       const githubInstance = await new GitHub(req.params)
+
+      expect.assertions(2)
 
       try {
         await githubInstance.writeFile(
@@ -361,9 +391,11 @@ describe('GitHub interface', () => {
           id: 1
         })
 
+      expect.assertions(5)
+
       const githubInstance = await new GitHub(req.params)
 
-      await githubInstance.writeFileAndSendReview(
+      const data = await githubInstance.writeFileAndSendReview(
         options.path,
         options.content,
         options.newBranch,
@@ -371,12 +403,12 @@ describe('GitHub interface', () => {
         options.commitBody
       )
 
-      setTimeout(() => {
-        expect(branchScope.isDone()).toBe(true)
-        expect(refsScope.isDone()).toBe(true)
-        expect(fileScope.isDone()).toBe(true)
-        expect(pullScope.isDone()).toBe(true)
-      })
+      expect(data).toEqual({"id": 1})
+
+      expect(branchScope.isDone()).toBe(true)
+      expect(refsScope.isDone()).toBe(true)
+      expect(fileScope.isDone()).toBe(true)
+      expect(pullScope.isDone()).toBe(true)
     })
 
     // TODO: Figure out why this works with no mocks
@@ -400,6 +432,8 @@ describe('GitHub interface', () => {
         .replyWithError('An error, oh no.')
 
       const githubInstance = await new GitHub(req.params)
+
+      expect.assertions(2)
 
       try {
         await githubInstance.writeFileAndSendReview(
@@ -447,6 +481,8 @@ describe('GitHub interface', () => {
         .replyWithError('Oops, an error')
 
       const githubInstance = await new GitHub(req.params)
+
+      expect.assertions(2)
 
       try {
         await githubInstance.getCurrentUser()


### PR DESCRIPTION
As pointed out in #327, many of the tests involving async code weren't using correct assertions and thus were incorrectly passing. I've resolved these issues with the relevant tests and have fixed some of the underlying issues with the GitHub library which were causing this behavior.

Many thanks to @travisdowns for the PR and issues which helped me greatly in resolving this.