### PR TITLE
Merge error handling fixes into master

### DIFF
--- a/lib/ErrorHandler.js
+++ b/lib/ErrorHandler.js
@@ -17,81 +17,83 @@ class ApiError {
   }
 }
 
-const ErrorHandler = function () {
-  this.ERROR_MESSAGES = {
-    'missing-input-secret': 'reCAPTCHA: The secret parameter is missing',
-    'invalid-input-secret': 'reCAPTCHA: The secret parameter is invalid or malformed',
-    'missing-input-response': 'reCAPTCHA: The response parameter is missing',
-    'invalid-input-response': 'reCAPTCHA: The response parameter is invalid or malformed',
-    'RECAPTCHA_MISSING_CREDENTIALS': 'Missing reCAPTCHA API credentials',
-    'RECAPTCHA_FAILED_DECRYPT': 'Could not decrypt reCAPTCHA secret',
-    'RECAPTCHA_CONFIG_MISMATCH': 'reCAPTCHA options do not match Staticman config',
-    'PARSING_ERROR': 'Error whilst parsing config file',
-    'GITHUB_AUTH_TOKEN_MISSING': 'The site requires a valid GitHub authentication token to be supplied in the `options[github-token]` field',
-    'MISSING_CONFIG_BLOCK': 'Error whilst parsing Staticman config file'
-  }
-
-  this.ERROR_CODE_ALIASES = {
-    'missing-input-secret': 'RECAPTCHA_MISSING_INPUT_SECRET',
-    'invalid-input-secret': 'RECAPTCHA_INVALID_INPUT_SECRET',
-    'missing-input-response': 'RECAPTCHA_MISSING_INPUT_RESPONSE',
-    'invalid-input-response': 'RECAPTCHA_INVALID_INPUT_RESPONSE'
-  }
-}
-
-ErrorHandler.prototype.getErrorCode = function (error) {
-  return this.ERROR_CODE_ALIASES[error] || error
-}
-
-ErrorHandler.prototype.getMessage = function (error) {
-  return this.ERROR_MESSAGES[error]
-}
-
-ErrorHandler.prototype.log = function (err, instance) {
-  let parameters = {}
-  let prefix = ''
-
-  if (instance) {
-    parameters = instance.getParameters()
-
-    prefix += `${parameters.username}/${parameters.repository}`
-  }
-
-  console.log(`${prefix}`, err)
-}
-
-ErrorHandler.prototype._save = function (errorCode, data = {}) {
-  const {err} = data
-
-  if (err) {
-    err._smErrorCode = err._smErrorCode || errorCode
-
-    // Re-wrap API request errors as these could expose
-    // request/response details that the user should not
-    // be allowed to see e.g. access tokens.
-    // `request-promise` is the primary offender here,
-    // but we similarly do not want others to leak too.
-    if (
-      err instanceof StatusCodeError ||
-      err instanceof RequestError
-    ) {
-      const statusCode = err.statusCode || err.code
-
-      return new ApiError(err.message, statusCode, err._smErrorCode)
+class ErrorHandler {
+  constructor () {
+    this.ERROR_MESSAGES = {
+      'missing-input-secret': 'reCAPTCHA: The secret parameter is missing',
+      'invalid-input-secret': 'reCAPTCHA: The secret parameter is invalid or malformed',
+      'missing-input-response': 'reCAPTCHA: The response parameter is missing',
+      'invalid-input-response': 'reCAPTCHA: The response parameter is invalid or malformed',
+      'RECAPTCHA_MISSING_CREDENTIALS': 'Missing reCAPTCHA API credentials',
+      'RECAPTCHA_FAILED_DECRYPT': 'Could not decrypt reCAPTCHA secret',
+      'RECAPTCHA_CONFIG_MISMATCH': 'reCAPTCHA options do not match Staticman config',
+      'PARSING_ERROR': 'Error whilst parsing config file',
+      'GITHUB_AUTH_TOKEN_MISSING': 'The site requires a valid GitHub authentication token to be supplied in the `options[github-token]` field',
+      'MISSING_CONFIG_BLOCK': 'Error whilst parsing Staticman config file'
     }
 
-    return err
+    this.ERROR_CODE_ALIASES = {
+      'missing-input-secret': 'RECAPTCHA_MISSING_INPUT_SECRET',
+      'invalid-input-secret': 'RECAPTCHA_INVALID_INPUT_SECRET',
+      'missing-input-response': 'RECAPTCHA_MISSING_INPUT_RESPONSE',
+      'invalid-input-response': 'RECAPTCHA_INVALID_INPUT_RESPONSE'
+    }
   }
 
-  let payload = {
-    _smErrorCode: errorCode
+  getErrorCode (error) {
+    return this.ERROR_CODE_ALIASES[error] || error
   }
 
-  if (data.data) {
-    payload.data = data.data
+  getMessage (error) {
+    return this.ERROR_MESSAGES[error]
   }
 
-  return payload
+  log (err, instance) {
+    let parameters = {}
+    let prefix = ''
+
+    if (instance) {
+      parameters = instance.getParameters()
+
+      prefix += `${parameters.username}/${parameters.repository}`
+    }
+
+    console.log(`${prefix}`, err)
+  }
+
+  _save (errorCode, data = {}) {
+    const {err} = data
+
+    if (err) {
+      err._smErrorCode = err._smErrorCode || errorCode
+
+      // Re-wrap API request errors as these could expose
+      // request/response details that the user should not
+      // be allowed to see e.g. access tokens.
+      // `request-promise` is the primary offender here,
+      // but we similarly do not want others to leak too.
+      if (
+        err instanceof StatusCodeError ||
+        err instanceof RequestError
+      ) {
+        const statusCode = err.statusCode || err.code
+
+        return new ApiError(err.message, statusCode, err._smErrorCode)
+      }
+
+      return err
+    }
+
+    let payload = {
+      _smErrorCode: errorCode
+    }
+
+    if (data.data) {
+      payload.data = data.data
+    }
+
+    return payload
+  }
 }
 
 const errorHandler = new ErrorHandler()

--- a/lib/GitHub.js
+++ b/lib/GitHub.js
@@ -117,7 +117,7 @@ class GitHub extends GitService {
           console.log(err)
         }
 
-        return Promise.reject(errorHandler('GITHUB_WRITING_FILE', {err}))
+        return Promise.reject(errorHandler('GITHUB_WRITING_FILE'))
       })
   }
 
@@ -182,7 +182,7 @@ class GitHub extends GitService {
     try {
       return await super.readFile(filePath, getFullResponse)
     } catch (err) {
-      return errorHandler('GITHUB_READING_FILE', {err})
+      throw errorHandler('GITHUB_READING_FILE', {err})
     }
   }
 

--- a/lib/GitService.js
+++ b/lib/GitService.js
@@ -51,7 +51,7 @@ class GitService {
     try {
       content = Buffer.from(res.content, 'base64').toString()
     } catch (err) {
-      return errorHandler('GITHUB_READING_FILE', {err})
+      throw errorHandler('GITHUB_READING_FILE', {err})
     }
 
     try {
@@ -85,7 +85,7 @@ class GitService {
         errorData.data = err.message
       }
 
-      return errorHandler('PARSING_ERROR', errorData)
+      throw errorHandler('PARSING_ERROR', errorData)
     }
   }
 

--- a/test/helpers/sampleData.js
+++ b/test/helpers/sampleData.js
@@ -150,6 +150,13 @@ module.exports.config3 = `comments:
     siteKey: "123456789"
     secret: "@reCaptchaSecret@"`
 
+module.exports.configInvalidYML = `invalid:
+- x
+y
+    foo
+bar
+`
+
 module.exports.prBody1 = `Dear human,
 
 Here's a new entry for your approval. :tada:


### PR DESCRIPTION
I'd like to merge the error handler fixes into master. These include:

* Convert error handler to more modern class declaration.
* Make GitHub and GitService actually throw errors rather than return them
* Fix some broken unit and acceptance tests