### PR TITLE
Add Makefile, config sample and edit README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ config.*.json
 coverage/
 node_modules/
 staticman_key
+config.mk
+id_rsa*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+include config.mk
+
+all: push-to-heroku test-connection
+
+push-to-heroku:
+	@git push -f heroku master
+
+create-ssh-key:
+	@ssh-keygen -m PEM -t rsa -b 4096 -C "staticman" -f id_rsa
+
+create-heroku:
+	@heroku create $(APP_NAME)
+
+config-heroku:
+	@heroku config:add "RSA_PRIVATE_KEY='$(shell cat id_rsa | tr -d "\n")'" "GITHUB_TOKEN=$(GITHUB_TOKEN)"
+	@heroku ps:scale web=1
+
+test-connection:
+	@curl -I https://$(APP_NAME).herokuapp.com/ 2>/dev/null | head -n 1
+
+setup: create-ssh-key create-heroku push-to-heroku config-heroku test-connection
+
+destroy:
+	@heroku apps:destroy --confirm $(APP_NAME)
+
+PHONY: all create-ssh-key create-heroku push-to-heroku config-heroku test-connection setup destroy

--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ Staticman is a Node.js application that receives user-generated content and uplo
 
 It consists of a small web service that handles the `POST` requests from your forms, runs various forms of validation and manipulation defined by you and finally pushes them to your repository as data files. You can choose to enable moderation, which means files will be pushed to a separate branch and a pull request will be created for your approval, or disable it completely, meaning that files will be pushed to the main branch automatically.
 
-You can download and run the Staticman API on your own infrastructure. The easiest way to get a personal Staticman API instance up and running is to use the free tier of Heroku. If deploying to Heroku you can simply click the button below and enter your config variables directly into Heroku as environment variables.
-
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
-
 ## Requirements
 
 - Node.js 8.11.3+
@@ -21,8 +17,24 @@ You can download and run the Staticman API on your own infrastructure. The easie
 - A [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) for the GitHub and/or GitLab account you want to run Staticman with
 - An RSA key in PEM format
 
+## Setting up your free Heroku instance (RECOMMENDED)
+
+- create a free account on Heroku and install the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli#download-and-install) on your workstation
+
+- clone the repository and install the dependencies via npm.
+
+    git clone git@github.com:eduardoboucas/staticman.git
+    cd staticman
+    npm install
+
+- Edit [config.sample.mk](config.sample.mk) adding the name for your Heroku app (e.g. `my-domain-com`) and your GitHub Token, save it as `config.mk`. NOTE: no quotes characters are needed around values, e.g.:
+
+    APP_NAME := my-domain-com
+    GITHUB_TOKEN := XXXXXXXYYYYYYYYYZZZZZZZZZZZ
+
+- run `make setup` and hit `ENTER` when asked for a _passphrase_ (and to confirm it, so `ENTER` to times). This should take care of setting up everything needed to expose your Staticman process to the public Internet
+
 ## Setting up the server on your own infrastructure
-NOTE: The below steps are not required if deploying to Heroku. To deploy to Heroku, click the above deploy button and enter your configuration variables in the Heroku Dashboard.
 
 - Clone the repository and install the dependencies via npm.
 

--- a/README.md
+++ b/README.md
@@ -19,20 +19,19 @@ It consists of a small web service that handles the `POST` requests from your fo
 
 ## Setting up your free Heroku instance (RECOMMENDED)
 
-- create a free account on Heroku and install the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli#download-and-install) on your workstation
+- Create a free account on Heroku and install the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli#download-and-install) on your workstation
 
-- clone the repository and install the dependencies via npm.
+- Clone the repository and change the working directory
 
     git clone git@github.com:eduardoboucas/staticman.git
     cd staticman
-    npm install
 
 - Edit [config.sample.mk](config.sample.mk) adding the name for your Heroku app (e.g. `my-domain-com`) and your GitHub Token, save it as `config.mk`. NOTE: no quotes characters are needed around values, e.g.:
 
     APP_NAME := my-domain-com
     GITHUB_TOKEN := XXXXXXXYYYYYYYYYZZZZZZZZZZZ
 
-- run `make setup` and hit `ENTER` when asked for a _passphrase_ (and to confirm it, so `ENTER` to times). This should take care of setting up everything needed to expose your Staticman process to the public Internet
+- Run `make setup` and hit `ENTER` when asked for a _passphrase_ (and to confirm it, so `ENTER` to times). This should take care of setting up everything needed to expose your Staticman process to the public Internet
 
 ## Setting up the server on your own infrastructure
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ It consists of a small web service that handles the `POST` requests from your fo
     APP_NAME := my-domain-com
     GITHUB_TOKEN := XXXXXXXYYYYYYYYYZZZZZZZZZZZ
 
-- Run `make setup` and hit `ENTER` when asked for a _passphrase_ (and to confirm it, so `ENTER` to times). This should take care of setting up everything needed to expose your Staticman process to the public Internet
+- Run `make setup` and hit `ENTER` when asked for a _passphrase_ (and to confirm it, so `ENTER` two times). This should take care of setting up everything needed to expose your Staticman process to the public Internet
 
 ## Setting up the server on your own infrastructure
 

--- a/config.sample.mk
+++ b/config.sample.mk
@@ -1,0 +1,2 @@
+APP_NAME := <your-staticman-app-name>
+GITHUB_TOKEN := <YOUR_GITHUB_TOKEN>


### PR DESCRIPTION
I believe the best way to improve the UX is to give the user the minimum amount of things to do, i.e. having something like a CLI utility that does all the heavy lifting.

I think Make is a good enough choice given that's quite ubiquitous in Unix-like systems (Linux, BSDs and macOS at least) so it should be a low-enough barrier.

I'm also for removing most of the documentation from the README and pointing directly to https://staticman.net to remove otehr confusion and inconsistencies, i.e. using https://staticman.net as anything authoritative on the usage of Staticman, and keeping the repository more focused on development.

@alexwaibel please let me know what you think