### PR TITLE
Site level configuration for Akismet and Mailgun

### DIFF
--- a/config.js
+++ b/config.js
@@ -6,14 +6,14 @@ const path = require('path')
 const schema = {
   akismet: {
     site: {
-      doc: 'URL of an Akismet account used for spam checking.',
+      doc: 'URL of an Akismet account used for spam checking. Will be overridden by a `akismet.site` parameter in the site config, if one is set.',
       docExample: 'http://yourdomain.com',
       format: String,
       default: null,
       env: 'AKISMET_SITE'
     },
     apiKey: {
-      doc: 'API key to be used with Akismet.',
+      doc: 'API key to be used with Akismet. Will be overridden by a `akismet.apiKey` parameter in the site config, if one is set.',
       format: String,
       default: null,
       env: 'AKISMET_API_KEY'

--- a/lib/Notification.js
+++ b/lib/Notification.js
@@ -1,8 +1,5 @@
 'use strict'
 
-const path = require('path')
-const config = require(path.join(__dirname, '/../config'))
-
 const Notification = function (mailAgent) {
   this.mailAgent = mailAgent
 }
@@ -29,7 +26,7 @@ Notification.prototype.send = function (to, fields, options, data) {
 
   return new Promise((resolve, reject) => {
     this.mailAgent.messages().send({
-      from: `Staticman <${config.get('email.fromAddress')}>`,
+      from: `Staticman <${data.fromAddress}>`,
       to,
       subject,
       html: this._buildMessage(fields, options, data)

--- a/lib/Staticman.js
+++ b/lib/Staticman.js
@@ -136,8 +136,8 @@ class Staticman {
 
     return new Promise((resolve, reject) => {
       const akismet = akismetApi.client({
-        apiKey: config.get('akismet.apiKey'),
-        blog: config.get('akismet.site')
+        apiKey: this.siteConfig.get('akismet.apiKey') || config.get('akismet.apiKey'),
+        blog: this.siteConfig.get('akismet.site') || config.get('akismet.site')
       })
 
       akismet.checkSpam({

--- a/lib/SubscriptionsManager.js
+++ b/lib/SubscriptionsManager.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const md5 = require('md5')
+const path = require('path')
+const config = require(path.join(__dirname, '/../config'))
 const Notification = require('./Notification')
 
 const SubscriptionsManager = function (parameters, dataStore, mailAgent) {
@@ -39,6 +41,7 @@ SubscriptionsManager.prototype.send = function (entryId, fields, options, siteCo
       const notifications = new Notification(this.mailAgent)
 
       return notifications.send(list, fields, options, {
+        fromAddress: siteConfig.get('notifications.fromAddress') || config.get('email.fromAddress'),
         siteName: siteConfig.get('name')
       })
     }

--- a/siteConfig.js
+++ b/siteConfig.js
@@ -21,6 +21,17 @@ const schema = {
       format: Boolean,
       default: false
     },
+    site: {
+      doc: 'URL of an Akismet account used for spam checking.',
+      docExample: 'http://yourdomain.com',
+      format: 'EncryptedString',
+      default: null
+    },
+    apiKey: {
+      doc: 'API key to be used with Akismet.',
+      format: 'EncryptedString',
+      default: null
+    },
     author: {
       doc: 'Name of the field to be used as the entry\'s author in Akistmet',
       format: String,

--- a/siteConfig.js
+++ b/siteConfig.js
@@ -142,12 +142,17 @@ const schema = {
       default: false
     },
     apiKey: {
-      doc: 'Mailgun API key',
+      doc: 'Mailgun API key to be used for email notifications.',
       format: 'EncryptedString',
       default: null
     },
     domain: {
-      doc: 'Mailgun domain',
+      doc: 'Domain to be used with Mailgun for email notifications.',
+      format: 'EncryptedString',
+      default: null
+    },
+    fromAddress: {
+      doc: 'Email address to send notifications from.',
       format: 'EncryptedString',
       default: null
     }

--- a/test/unit/lib/Notification.test.js
+++ b/test/unit/lib/Notification.test.js
@@ -18,6 +18,7 @@ beforeEach(() => {
 describe('Notification interface', () => {
   const mockData = {
     data: {
+      fromAddress: `${config.get('email.fromAddress')}`,
       siteName: 'Eduardo\'s blog'
     },
     fields: {


### PR DESCRIPTION
This PR aimed to cover issue #369 and #370. Following properties was added into siteConfig in this PR, which allowing site owner to override them on per site basis.

- `akismet.site`: Site URL defined on Akismet. Should be an `EncryptedString`.
- `akismet.apiKey`: ApiKey provided by Akismet. Should be an `EncryptedString`.
- `notifications.fromAddress`: Custom sender address. Should be an `EncryptedString`. This property should match to the domain configured in same section. This property was documented as overridable but not implemented.

This PR also update the notification template to make overridden sender address take effect.