### PR TITLE
Allow for customizing the name of the sender to put on notification emails

### DIFF
--- a/config.js
+++ b/config.js
@@ -42,10 +42,16 @@ const schema = {
       env: 'EMAIL_DOMAIN'
     },
     fromAddress: {
-      doc: 'Email address to send notifications from. Will be overridden by a `notifications.fromAddress` parameter in the site config, if one is set.',
+      doc: 'Email address to send notifications from.',
       format: String,
       default: 'noreply@staticman.net',
       env: 'EMAIL_FROM'
+    },
+    fromName: {
+      doc: 'Name of the sender to put on notification emails.',
+      format: String,
+      default: 'Staticman',
+      env: 'EMAIL_FROM_NAME'
     }
   },
   env: {

--- a/lib/Notification.js
+++ b/lib/Notification.js
@@ -29,7 +29,7 @@ Notification.prototype.send = function (to, fields, options, data) {
 
   return new Promise((resolve, reject) => {
     this.mailAgent.messages().send({
-      from: `Staticman <${config.get('email.fromAddress')}>`,
+      from: `${config.get('email.fromName')} <${config.get('email.fromAddress')}>`,
       to,
       subject,
       html: this._buildMessage(fields, options, data)

--- a/test/unit/lib/Notification.test.js
+++ b/test/unit/lib/Notification.test.js
@@ -51,7 +51,7 @@ describe('Notification interface', () => {
 
     expect(mockSendFn.mock.calls.length).toBe(1)
     expect(mockSendFn.mock.calls[0][0]).toEqual({
-      from: `Staticman <${config.get('email.fromAddress')}>`,
+      from: `${config.get('email.fromName')} <${config.get('email.fromAddress')}>`,
       to: recipient,
       subject: `New reply on "${mockData.data.siteName}"`,
       html: message


### PR DESCRIPTION
This addresses issue https://github.com/eduardoboucas/staticman/issues/392 - "Provide support for customizing the name of the sender on notification emails".

The changes for this are minimal. 
  - I added a new email.fromName property to the JSON config schema. The default value is "Staticman".
  - I added a reference to this new property in Notification.js

While in there, I corrected the doc for the email.fromAddress property.

The relevant unit test has been updated. I performed integration testing on Heroku.

The changes here overlap with changes made for PR https://github.com/eduardoboucas/staticman/pull/391. If that PR is merged-in before this one and that makes this merge burdensome, please LMK and I can re-create this PR. If/when this is merged-in, I'll be happy to submit a PR to update the documentation site.

Thank you for Staticman!