### PR TITLE
Allow the use of Mailgun's EU region

### DIFF
--- a/source/config.js
+++ b/source/config.js
@@ -27,6 +27,12 @@ export const schema = {
     },
   },
   email: {
+    apiHost: {
+      doc: 'The Mailgun host to use. Note that if you are using the EU region the host should be set to `api.eu.mailgun.net`. Will be overridden by a `notifications.apiHost` parameter in the site config, if one is set.',
+      format: String,
+      default: 'api.mailgun.net',
+      env: 'EMAIL_API_HOST'
+    },
     apiKey: {
       doc:
         'Mailgun API key to be used for email notifications. Will be overridden by a `notifications.apiKey` parameter in the site config, if one is set.',

--- a/source/lib/Staticman.js
+++ b/source/lib/Staticman.js
@@ -357,7 +357,9 @@ export default class Staticman {
     if (!this.siteConfig.get('notifications.enabled')) return null;
 
     // Initialise Mailgun
+    const mailgunHost = this.siteConfig.get('notifications.apiHost') || config.get('email.apiHost')
     const mailgun = Mailgun({
+      ...(mailgunHost && { host: mailgunHost }),
       apiKey: this.siteConfig.get('notifications.apiKey') || config.get('email.apiKey'),
       domain: this.siteConfig.get('notifications.domain') || config.get('email.domain'),
     });

--- a/source/siteConfig.js
+++ b/source/siteConfig.js
@@ -149,6 +149,11 @@ export const schema = {
       format: Boolean,
       default: false,
     },
+    apiHost: {
+      doc: 'Mailgun API host. Note that if you are using the EU region the host should be set to `api.eu.mailgun.net`.',
+      format: String,
+      default: 'api.mailgun.net'
+    },
     apiKey: {
       doc: 'Mailgun API key',
       format: 'EncryptedString',

--- a/staticman.sample.yml
+++ b/staticman.sample.yml
@@ -52,6 +52,9 @@ comments:
   # Enable notifications
   #enabled: true
 
+  # Mailgun API host name.  If in EU Region, use 'api.eu.mailgun.net'
+  #apiHost: api.mailgun.net
+
   # (!) ENCRYPTED
   #
   # Mailgun API key


### PR DESCRIPTION
This is a proposition similar to what was merged before (and has disappeared?). The only difference is the use of a spread operator: the host is thus optional and will rely on mailgun-js's default if not provided.

I've applied and used this change successfully on my own Staticman installation (based on master).