### PR TITLE
feat: Add docker build and publish workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,7 +5,8 @@ name: Create and publish a Docker image
 
 on:
   push:
-    branches: ['master','feat/bk_add_docker_build_workflow']
+    branches: ['master']
+    tags: ['v[0-9]+.[0-9]+.[0-9]+.*']
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,7 +6,7 @@ name: Create and publish a Docker image
 on:
   push:
     branches: ['master']
-    tags: ['v[0-9]+\.[0-9]+\.[0-9]+.*']
+    tags: ['v*']
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,7 +6,7 @@ name: Create and publish a Docker image
 on:
   push:
     branches: ['master']
-    tags: ['v[0-9]+.[0-9]+.[0-9]+.*']
+    tags: ['v[0-9]+\.[0-9]+\.[0-9]+.*']
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,44 @@
+# Based on example from GitHub Docs
+# https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages
+
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches: ['master','feat/bk_add_docker_build_workflow']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,45 @@
+# Based on example from GitHub Docs
+# https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages
+
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches: ['master']
+    tags: ['v[0-9]+.[0-9]+.[0-9]+.*']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Builds and publishes images to GitHub Docker Image Registry (both free for open source projects).  One less step to self host staticman on local machine, or in the Cloud on AWS ECS, or Google Cloud Run

Results in docker image that can be seen from the GitHub repo page, with instructions to pull:
https://github.com/bryankaraffa/staticman/pkgs/container/staticman