### PR TITLE
feat: add docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,6 +8,8 @@ on:
     branches: ['dev','master']
     tags: ['v*']
 
+  workflow_dispatch:
+
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
@@ -26,22 +28,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Log in to Docker Hub
-      #   uses: docker/login-action@v2
-      #   with:
-      #     username: ${{ secrets.DOCKER_USERNAME }}
-      #     password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4
         with:
-          # GCR:        gcr.io/bryankaraffa/staticman
-          # Docker Hub: bryankaraffa/staticman 
-          #             https://hub.docker.com/r/bryankaraffa/staticman
+          # GCR:        gcr.io/${{ github.repository }}
+          # Docker Hub: ${{ github.repository }}
           images: |
-            ghcr.io/${{ github.repository }}
-          # ${{ github.repository }}
+            ${{ github.repository }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,52 @@
+# Based on example from GitHub Docs
+# https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages
+
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches: ['dev','master']
+    tags: ['v*','testing']
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # - name: Log in to Docker Hub
+      #   uses: docker/login-action@v2
+      #   with:
+      #     username: ${{ secrets.DOCKER_USERNAME }}
+      #     password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          # GCR:        gcr.io/bryankaraffa/staticman
+          # Docker Hub: bryankaraffa/staticman 
+          #             https://hub.docker.com/r/bryankaraffa/staticman
+          images: |
+            ghcr.io/${{ github.repository }}
+          # ${{ github.repository }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,7 +6,7 @@ name: Create and publish a Docker image
 on:
   push:
     branches: ['dev','master']
-    tags: ['v*','testing']
+    tags: ['v*']
 
 jobs:
   build-and-push-image:


### PR DESCRIPTION
 - Adds GitHub Actions workflow to build and publish the docker image to GitHub Container Registry
 
Optional: Also enable publishing to Docker Hub
- Uncomment [L29-L33](https://github.com/bryankaraffa/staticman-bk/blob/dev/.github/workflows/docker-publish.yml#L29-L33) and [L44](https://github.com/bryankaraffa/staticman-bk/blob/dev/.github/workflows/docker-publish.yml#L44)
- Add `DOCKER_USERNAME` and `DOCKER_SECRET` Secrets to your GitHub Repo Settings [Settings > Secrets and variables > Actions](https://github.com/eduardoboucas/staticman/settings/secrets/actions)
This would be helpful to enable use-cases where we can pull images from Docker Hub but not GitHub Container Registry (i.e. Google Cloud Run)